### PR TITLE
Multicast/mc key frame

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -6159,6 +6159,36 @@ int picoquic_process_ack_of_observed_address_frame(picoquic_cnx_t* cnx, picoquic
     return ret;
 }
 
+picoquic_mc_channel_in_cnx_t* picoquic_add_channel_to_cnx(picoquic_cnx_t* cnx, picoquic_multicast_channel_t* channel) {
+    picoquic_mc_channel_in_cnx_t* new_channel_in_cnx = malloc(sizeof(picoquic_mc_channel_in_cnx_t));
+    if (new_channel_in_cnx == NULL) {
+        fprintf(stderr, "could not create picoquic_mc_channel_in_cnx_t: malloc failed\n");
+        return NULL;
+    }
+
+    picoquic_mc_channel_in_cnx_t** new_channel_list = (picoquic_mc_channel_in_cnx_t **)malloc((cnx->nb_mc_channels + 1) * sizeof(picoquic_mc_channel_in_cnx_t *));
+
+    if (new_channel_list == NULL) { 
+        return NULL;
+    }
+
+    if (cnx->mc_channels != NULL) {
+        memset(new_channel_list, 0, sizeof(picoquic_mc_channel_in_cnx_t*));
+        if (cnx->nb_mc_channels > 0) {
+            memcpy(new_channel_list, cnx->mc_channels, cnx->nb_mc_channels * sizeof(picoquic_mc_channel_in_cnx_t *));
+        }
+        free(cnx->mc_channels);
+    }
+    cnx->mc_channels = new_channel_list;
+
+    memset(new_channel_in_cnx, 0, sizeof(picoquic_mc_channel_in_cnx_t));
+
+    cnx->mc_channels[cnx->nb_mc_channels] = new_channel_in_cnx;
+    cnx->nb_mc_channels++;
+
+    return new_channel_in_cnx;
+}
+
 uint8_t* picoquic_format_mc_announce_frame(uint8_t* bytes, const uint8_t* bytes_max, picoquic_multicast_channel_t* channel, picoquic_path_t* path_x, int * more_data)
 {
     uint64_t ftype = 0;
@@ -6274,13 +6304,8 @@ const uint8_t* picoquic_decode_mc_announce_frame(picoquic_cnx_t* cnx, const uint
         return NULL;
     }
 
-    picoquic_multicast_channel_t* channel = malloc(sizeof(picoquic_multicast_channel_t));
-    if (channel == NULL) {
-        fprintf(stderr, "could not create multicast channel: malloc failed\n");
-        return NULL;
-    }
-
     uint8_t id_len;
+    picoquic_multicast_channel_id_t channel_id;
 
     // Channel ID Length
     if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &id_len)) == NULL) {
@@ -6288,22 +6313,37 @@ const uint8_t* picoquic_decode_mc_announce_frame(picoquic_cnx_t* cnx, const uint
     }
 
     // Channel ID
-    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes, id_len, &channel->channel_id);
+    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes, id_len, &channel_id);
+    picoquic_mc_channel_in_cnx_t* channel_found;
+
     if (bytes_copied == 0) {
         return NULL;
+    } 
+
+    bytes += bytes_copied;
+
+    // Channel could already exist in cnx if MC_KEY was decoded before MC_ANNOUNCE frame
+    if ((channel_found = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx)) != NULL && channel_found->state >= 2) {
+        fprintf(stderr, "Received a duplicate MC_ANNOUNCE for channel\n");
+        return NULL;
+    }
+    
+    picoquic_multicast_channel_t* channel;
+    if (channel_found != NULL) {
+        channel = channel_found->channel;
     } else {
-        if (picoquic_multicast_channel_id_exists_in_cnx(&channel->channel_id, cnx) != 0) {
-            fprintf(stderr, "Received a duplicate MC_ANNOUNCE for channel\n");
+        channel = malloc(sizeof(picoquic_multicast_channel_t));
+        if (channel == NULL) {
+            fprintf(stderr, "could not create multicast channel: malloc failed\n");
             return NULL;
         }
 
-        bytes += bytes_copied;
+        channel->channel_id = channel_id;
     }
 
     // if not enough bytes received for two addresses (src and group), then error
     if ((addr_family == AF_INET && bytes + 8 > bytes_max)
-    || (addr_family == AF_INET6 && bytes + 32 > bytes_max)) 
-    {
+    || (addr_family == AF_INET6 && bytes + 32 > bytes_max)) {
         return NULL;
     }
     
@@ -6364,31 +6404,175 @@ const uint8_t* picoquic_decode_mc_announce_frame(picoquic_cnx_t* cnx, const uint
         return NULL;
     }
 
-    picoquic_mc_channel_in_cnx_t* new_channel_in_cnx = malloc(sizeof(picoquic_mc_channel_in_cnx_t));
-    if (new_channel_in_cnx == NULL) {
+    picoquic_mc_channel_in_cnx_t* new_channel_in_cnx;
+
+    if (channel_found != NULL) {
+        new_channel_in_cnx = channel_found;
+    } else {
+        new_channel_in_cnx = picoquic_add_channel_to_cnx(cnx, channel);
+        if (new_channel_in_cnx == NULL) {
+            fprintf(stderr, "could not create picoquic_mc_channel_in_cnx_t\n");
+            return NULL;
+        }
+        new_channel_in_cnx->channel = channel;
+    }
+    
+    new_channel_in_cnx->state = 2; // "announced"
+
+    return bytes;
+}
+
+const uint8_t* picoquic_format_mc_key_frame(uint8_t* bytes, uint8_t* bytes_max, picoquic_multicast_channel_t* channel, picoquic_multicast_aead_secret_t* aead, int* more_data) {
+    uint8_t* bytes0 = bytes;
+
+    // Frame type
+    // Channel ID Length
+    if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, picoquic_frame_type_mc_key)) == NULL
+        || (bytes = picoquic_frames_uint8_encode(bytes, bytes_max, channel->channel_id.id_len)) == NULL) {
+        *more_data = 1;
+        return bytes0;
+    }
+
+    // CLEAN MC: Refactor event/error logging to qlog    
+    fprintf(stdout, "Send Key for MC Channel with ID: ");
+    print_hex_bytes(channel->channel_id.id, channel->channel_id.id_len);
+    fprintf(stdout, "\n");
+    
+    // Channel ID
+    uint8_t bytes_copied = picoquic_format_multicast_channel_id(bytes, bytes_max - bytes, channel->channel_id);
+    if (bytes_copied == 0) {
+        *more_data = 1;
+        return bytes0;
+    } else {
+        bytes += bytes_copied;
+    }
+
+    // Key Seq Number
+    // From Pkt Number
+    // Secret Length
+    if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, aead->key_seq_number)) == NULL
+        || (bytes = picoquic_frames_varint_encode(bytes, bytes_max, aead->from_pkt_number)) == NULL
+        || (bytes = picoquic_frames_varint_encode(bytes, bytes_max, aead->secret_len)) == NULL) {
+        *more_data = 1;
+        return bytes0;
+    }
+
+    // Secret
+    if ((bytes + aead->secret_len) > bytes_max) {
+        return NULL;
+    } else {
+        memcpy(aead->secret, bytes, aead->secret_len);
+        bytes += aead->secret_len;
+    }
+
+    return bytes;
+}
+
+const uint8_t* picoquic_decode_mc_key_frame(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max) {
+    if (!cnx->is_multicast_enabled || !cnx->client_mode) {
+        picoquic_connection_error_ex(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, picoquic_frame_type_mc_key, "received unexpected MC_KEY frame");
+        return NULL;
+    }
+
+    uint8_t channel_id_len;
+    picoquic_multicast_channel_id_t channel_id;
+
+    // Channel ID Length
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, channel_id_len)) == NULL) {
+        return NULL;
+    }
+    
+    // Channel ID
+    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes, bytes_max - bytes, &channel_id);
+    if (bytes_copied == 0) {
+        return NULL;
+    } else {
+        bytes += bytes_copied;
+    }
+
+    picoquic_mc_channel_in_cnx_t* channel_found = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx);
+    
+    picoquic_multicast_channel_t* channel;
+    if (channel_found != NULL) {
+        channel = channel_found->channel;
+    } else {
+        channel = malloc(sizeof(picoquic_multicast_channel_t));
+        if (channel == NULL) {
+            fprintf(stderr, "could not create multicast channel: malloc failed\n");
+            return NULL;
+        }
+
+        channel->channel_id = channel_id;
+    }
+
+    picoquic_multicast_aead_secret_t* aead = malloc(sizeof(picoquic_multicast_aead_secret_t));
+    if (aead == NULL) {
         fprintf(stderr, "could not create picoquic_mc_channel_in_cnx_t: malloc failed\n");
         return NULL;
     }
 
-    picoquic_mc_channel_in_cnx_t** new_channel_list = (picoquic_mc_channel_in_cnx_t **)malloc((cnx->nb_mc_channels + 1) * sizeof(picoquic_mc_channel_in_cnx_t *));
+    memset(aead, 0, sizeof(picoquic_multicast_aead_secret_t));
 
-    if (new_channel_list != NULL) {
-        if (cnx->mc_channels != NULL) {
-            memset(new_channel_list, 0, sizeof(picoquic_mc_channel_in_cnx_t*));
-            if (cnx->nb_mc_channels > 0) {
-                memcpy(new_channel_list, cnx->mc_channels, cnx->nb_mc_channels * sizeof(picoquic_mc_channel_in_cnx_t *));
-            }
-            free(cnx->mc_channels);
-        }
-        cnx->mc_channels = new_channel_list;
+    // Key Seq Number
+    // From Pkt Number
+    // Secret Length
+    if ((bytes = picoquic_frames_varint_decode(bytes, bytes_max, aead->key_seq_number)) == NULL
+        || (bytes = picoquic_frames_varint_decode(bytes, bytes_max, aead->from_pkt_number)) == NULL
+        || (bytes = picoquic_frames_varint_decode(bytes, bytes_max, aead->secret_len)) == NULL) {
+        return NULL;
     }
 
-    memset(new_channel_in_cnx, 0, sizeof(picoquic_mc_channel_in_cnx_t));
-    new_channel_in_cnx->channel = channel;
-    new_channel_in_cnx->state = 2; // "announced"
+    // Validate key properties
+    if (channel_found != NULL && channel_found->key_available == 1 && channel_found->channel->nb_aead_secrets > 0 && 
+        (channel_found->latest_key_sequence_available + 1 != aead->key_seq_number
+        || channel_found->channel->aead_secrets[channel_found->channel->nb_aead_secrets]->from_pkt_number > aead->from_pkt_number)) 
+    {
+        fprintf(stderr, "Error: Received a MC_KEY with invalid properties\n");
+        return NULL;
+    }
 
-    cnx->mc_channels[cnx->nb_mc_channels] = new_channel_in_cnx;
+    // Secret
+    if ((bytes + aead->secret_len) > bytes_max) {
+        return NULL;
+    } else {
+        memcpy(aead->secret, bytes, aead->secret_len);
+        bytes += aead->secret_len;
+    }
+
+    // Add aead object to channel
+    picoquic_multicast_aead_secret_t** new_aead_list = (picoquic_multicast_aead_secret_t **)malloc((channel->nb_aead_secrets + 1) * sizeof(picoquic_multicast_aead_secret_t *));
+    if (new_aead_list == NULL) { 
+        return NULL;
+    }
+
+    if (channel->aead_secrets != NULL) {
+        memset(new_aead_list, 0, sizeof(picoquic_multicast_aead_secret_t*));
+        if (channel->nb_aead_secrets > 0) {
+            memcpy(new_aead_list, channel->aead_secrets, channel->nb_aead_secrets * sizeof(picoquic_multicast_aead_secret_t *));
+        }
+        free(channel->aead_secrets);
+    }
+    channel->aead_secrets = new_aead_list;
+
+    channel->aead_secrets[channel->nb_aead_secrets] = aead;
     cnx->nb_mc_channels++;
+
+    // Add channel to cnx if not already done
+    picoquic_mc_channel_in_cnx_t* new_channel_in_cnx;
+
+    if (channel_found != NULL) {
+        new_channel_in_cnx = channel_found;
+    } else {
+        new_channel_in_cnx = picoquic_add_channel_to_cnx(cnx, channel);
+        if (new_channel_in_cnx == NULL) {
+            fprintf(stderr, "could not create picoquic_mc_channel_in_cnx_t\n");
+            return NULL;
+        }
+        new_channel_in_cnx->channel = channel;
+    }
+    
+    new_channel_in_cnx->key_available = 1;
+    new_channel_in_cnx->latest_key_sequence_available = aead->key_seq_number;
 
     return bytes;
 }

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -52,6 +52,14 @@ int picoquic_process_ack_of_path_cid_blocked_frame(picoquic_cnx_t* cnx, const ui
     size_t bytes_max, size_t* consumed);
 int picoquic_process_ack_of_observed_address_frame(picoquic_cnx_t* cnx, picoquic_path_t* path_x, const uint8_t* bytes,
     size_t bytes_max, uint64_t ftype, size_t* consumed);
+int picoquic_process_ack_of_mc_announce_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
+    size_t bytes_size, uint64_t ftype, size_t* consumed);
+int picoquic_check_mc_announce_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes, 
+    const uint8_t* bytes_max, int* no_need_to_repeat);
+int picoquic_process_ack_of_mc_key_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
+    size_t bytes_size, size_t* consumed);
+int picoquic_check_mc_key_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes, 
+    const uint8_t* bytes_max, int* no_need_to_repeat);
 
 picoquic_stream_head_t* picoquic_create_missing_streams(picoquic_cnx_t* cnx, uint64_t stream_id, int is_remote)
 {
@@ -3395,6 +3403,13 @@ int picoquic_check_frame_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes,
                     /* These frames have a special case processing, tied to path challenge */
                     ret = 0;
                     break;
+                case picoquic_frame_type_mc_announce_v4:
+                case picoquic_frame_type_mc_announce_v6:
+                    ret = picoquic_check_mc_announce_needs_repeat(cnx, bytes, p_bytes_max, no_need_to_repeat);
+                    break;
+                case picoquic_frame_type_mc_key:
+                    ret = picoquic_check_mc_key_needs_repeat(cnx, bytes, p_bytes_max, no_need_to_repeat);
+                    break;
                 default:
                     *no_need_to_repeat = 0;
                     break;
@@ -3543,6 +3558,15 @@ void picoquic_process_ack_of_frames(picoquic_cnx_t* cnx, picoquic_packet_t* p,
         case picoquic_frame_type_observed_address_v4:
         case picoquic_frame_type_observed_address_v6:
             ret = picoquic_process_ack_of_observed_address_frame(cnx, p->send_path, &p->bytes[byte_index], p->length - byte_index, ftype, &frame_length);
+            byte_index += frame_length;
+            break;
+        case picoquic_frame_type_mc_announce_v4:
+        case picoquic_frame_type_mc_announce_v6:
+            ret = picoquic_process_ack_of_mc_announce_frame(cnx, &p->bytes[byte_index], p->length - byte_index, ftype, &frame_length);
+            byte_index += frame_length;
+            break;
+        case picoquic_frame_type_mc_key:
+            ret = picoquic_process_ack_of_mc_key_frame(cnx, &p->bytes[byte_index], p->length - byte_index, &frame_length);
             byte_index += frame_length;
             break;
         default:
@@ -6183,13 +6207,14 @@ picoquic_mc_channel_in_cnx_t* picoquic_add_channel_to_cnx(picoquic_cnx_t* cnx, p
 
     memset(new_channel_in_cnx, 0, sizeof(picoquic_mc_channel_in_cnx_t));
 
+    new_channel_in_cnx->channel = channel;
     cnx->mc_channels[cnx->nb_mc_channels] = new_channel_in_cnx;
     cnx->nb_mc_channels++;
 
     return new_channel_in_cnx;
 }
 
-uint8_t* picoquic_format_mc_announce_frame(uint8_t* bytes, const uint8_t* bytes_max, picoquic_multicast_channel_t* channel, picoquic_path_t* path_x, int * more_data)
+uint8_t* picoquic_format_mc_announce_frame(uint8_t* bytes, uint8_t* bytes_max, picoquic_multicast_channel_t* channel, picoquic_path_t* path_x, int * more_data)
 {
     uint64_t ftype = 0;
 
@@ -6414,7 +6439,6 @@ const uint8_t* picoquic_decode_mc_announce_frame(picoquic_cnx_t* cnx, const uint
             fprintf(stderr, "could not create picoquic_mc_channel_in_cnx_t\n");
             return NULL;
         }
-        new_channel_in_cnx->channel = channel;
     }
     
     new_channel_in_cnx->state = 2; // "announced"
@@ -6422,7 +6446,110 @@ const uint8_t* picoquic_decode_mc_announce_frame(picoquic_cnx_t* cnx, const uint
     return bytes;
 }
 
-const uint8_t* picoquic_format_mc_key_frame(uint8_t* bytes, uint8_t* bytes_max, picoquic_multicast_channel_t* channel, picoquic_multicast_aead_secret_t* aead, int* more_data) {
+const uint8_t* picoquic_skip_mc_announce_frame(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t ftype)
+{
+    uint8_t ch_id_length = 0;
+    uint64_t secret_length = 0;
+
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &ch_id_length)) != NULL && // channel id length
+        (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, (uint64_t)ch_id_length)) != NULL && // channel id
+        (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, ftype == picoquic_frame_type_mc_announce_v4 ? 4 : 16)) != NULL && // source ip
+        (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, ftype == picoquic_frame_type_mc_announce_v4 ? 4 : 16)) != NULL && // group ip
+        (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, 2)) != NULL && // udp port
+        (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, 2)) != NULL && // header protection algo
+        (bytes = picoquic_frames_varint_decode(bytes, bytes_max, &secret_length)) != NULL && // header secret length
+        (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, secret_length)) != NULL && // header secret
+        (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, 2)) != NULL && // aead algorithm
+        (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, 2)) != NULL && // integrity hash algo
+        (bytes = picoquic_frames_varint_skip(bytes, bytes_max)) != NULL) { // max rate
+            bytes = picoquic_frames_varint_skip(bytes, bytes_max); // max ack delay
+        }
+
+    return bytes;
+}
+
+int picoquic_process_ack_of_mc_announce_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
+    size_t bytes_size, uint64_t ftype, size_t* consumed)
+{
+    const uint8_t* bytes_first = bytes;
+    const uint8_t* bytes_max = bytes + bytes_size;
+
+    // Skip frame type
+    const uint8_t* bytes_after_ftype = bytes = picoquic_frames_varint_skip(bytes, bytes_max);
+
+    uint8_t id_len;
+    picoquic_multicast_channel_id_t channel_id;
+
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &id_len)) == NULL) {
+        return -1;
+    }
+
+    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes, id_len, &channel_id);
+
+    if (bytes_copied == 0) {
+        return -1;
+    }
+
+    int ret = 0;
+    const uint8_t* bytes_next = picoquic_skip_mc_announce_frame(bytes_after_ftype, bytes_max, ftype);
+
+    if (bytes_next == NULL) {
+        return -1;
+    }
+    else {
+        picoquic_mc_channel_in_cnx_t* ch_in_cnx = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx);
+        if (ch_in_cnx == NULL) {
+            return -1;
+        }
+        ch_in_cnx->mc_announce_acked = 1;
+        *consumed = bytes_next - bytes_first;
+    }
+    
+    fprintf(stdout, "ACK of MC_ANNOUNCE successfully processed\n");
+    return ret;
+}
+
+int picoquic_check_mc_announce_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes, const uint8_t* bytes_max, int* no_need_to_repeat)
+{
+    int ret = 0;
+    const uint8_t* bytes_parsing = bytes;
+    uint8_t id_len;
+    picoquic_multicast_channel_id_t channel_id;
+    *no_need_to_repeat = 0;
+
+    if ((bytes_parsing = picoquic_frames_uint8_decode(bytes_parsing, bytes_max, &id_len)) == NULL) {
+        *no_need_to_repeat = 1;
+        return -1;
+    }
+
+    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes_parsing, id_len, &channel_id);
+
+    if (bytes_copied == 0) {
+        *no_need_to_repeat = 1;
+        return -1;
+    }
+
+    picoquic_mc_channel_in_cnx_t* ch_in_cnx;
+
+    if ((ch_in_cnx = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx)) == NULL) {
+        /* If the channel is not in the connection (anymore?), no need to repeat this frame. */
+        *no_need_to_repeat = 1;
+    }
+    else if (ch_in_cnx->state >= 15 || ch_in_cnx->mc_announce_acked == 1) {
+        /* If MC_ANNOUNCE was acked or client left the channel or intends to leave it, do not repeat */
+        *no_need_to_repeat = 1;
+    }
+
+    if (*no_need_to_repeat == 0) {
+        fprintf(stdout, "MC_ANNOUNCE needs repeat\n");
+    } else {
+        fprintf(stdout, "MC_ANNOUNCE do not need repeat\n");
+    }
+
+    return ret;
+}
+
+uint8_t* picoquic_format_mc_key_frame(uint8_t* bytes, uint8_t* bytes_max, picoquic_multicast_channel_t* channel, picoquic_multicast_aead_secret_t* aead, int* more_data) {
     uint8_t* bytes0 = bytes;
 
     // Frame type
@@ -6434,10 +6561,10 @@ const uint8_t* picoquic_format_mc_key_frame(uint8_t* bytes, uint8_t* bytes_max, 
     }
 
     // CLEAN MC: Refactor event/error logging to qlog    
-    fprintf(stdout, "Send Key for MC Channel with ID: ");
+    fprintf(stdout, "Send MC_KEY for Channel with ID: ");
     print_hex_bytes(channel->channel_id.id, channel->channel_id.id_len);
     fprintf(stdout, "\n");
-    
+
     // Channel ID
     uint8_t bytes_copied = picoquic_format_multicast_channel_id(bytes, bytes_max - bytes, channel->channel_id);
     if (bytes_copied == 0) {
@@ -6461,14 +6588,14 @@ const uint8_t* picoquic_format_mc_key_frame(uint8_t* bytes, uint8_t* bytes_max, 
     if ((bytes + aead->secret_len) > bytes_max) {
         return NULL;
     } else {
-        memcpy(aead->secret, bytes, aead->secret_len);
+        memcpy(bytes, aead->secret, aead->secret_len);
         bytes += aead->secret_len;
     }
 
     return bytes;
 }
 
-const uint8_t* picoquic_decode_mc_key_frame(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max) {
+const uint8_t* picoquic_decode_mc_key_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, const uint8_t* bytes_max) {
     if (!cnx->is_multicast_enabled || !cnx->client_mode) {
         picoquic_connection_error_ex(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, picoquic_frame_type_mc_key, "received unexpected MC_KEY frame");
         return NULL;
@@ -6478,12 +6605,12 @@ const uint8_t* picoquic_decode_mc_key_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
     picoquic_multicast_channel_id_t channel_id;
 
     // Channel ID Length
-    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, channel_id_len)) == NULL) {
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &channel_id_len)) == NULL) {
         return NULL;
     }
-    
+
     // Channel ID
-    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes, bytes_max - bytes, &channel_id);
+    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes, channel_id_len, &channel_id);
     if (bytes_copied == 0) {
         return NULL;
     } else {
@@ -6491,7 +6618,7 @@ const uint8_t* picoquic_decode_mc_key_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
     }
 
     picoquic_mc_channel_in_cnx_t* channel_found = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx);
-    
+
     picoquic_multicast_channel_t* channel;
     if (channel_found != NULL) {
         channel = channel_found->channel;
@@ -6516,9 +6643,9 @@ const uint8_t* picoquic_decode_mc_key_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
     // Key Seq Number
     // From Pkt Number
     // Secret Length
-    if ((bytes = picoquic_frames_varint_decode(bytes, bytes_max, aead->key_seq_number)) == NULL
-        || (bytes = picoquic_frames_varint_decode(bytes, bytes_max, aead->from_pkt_number)) == NULL
-        || (bytes = picoquic_frames_varint_decode(bytes, bytes_max, aead->secret_len)) == NULL) {
+    if ((bytes = picoquic_frames_varint_decode(bytes, bytes_max, &aead->key_seq_number)) == NULL
+        || (bytes = picoquic_frames_varint_decode(bytes, bytes_max, &aead->from_pkt_number)) == NULL
+        || (bytes = picoquic_frames_varint_decode(bytes, bytes_max, &aead->secret_len)) == NULL) {
         return NULL;
     }
 
@@ -6532,7 +6659,8 @@ const uint8_t* picoquic_decode_mc_key_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
     }
 
     // Secret
-    if ((bytes + aead->secret_len) > bytes_max) {
+    // 48 is currently the global max in picoquic for aead secret len
+    if ((bytes + aead->secret_len) > bytes_max || aead->secret_len > 48) {
         return NULL;
     } else {
         memcpy(aead->secret, bytes, aead->secret_len);
@@ -6555,7 +6683,7 @@ const uint8_t* picoquic_decode_mc_key_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
     channel->aead_secrets = new_aead_list;
 
     channel->aead_secrets[channel->nb_aead_secrets] = aead;
-    cnx->nb_mc_channels++;
+    channel->nb_aead_secrets++;
 
     // Add channel to cnx if not already done
     picoquic_mc_channel_in_cnx_t* new_channel_in_cnx;
@@ -6568,13 +6696,105 @@ const uint8_t* picoquic_decode_mc_key_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
             fprintf(stderr, "could not create picoquic_mc_channel_in_cnx_t\n");
             return NULL;
         }
-        new_channel_in_cnx->channel = channel;
     }
-    
+
     new_channel_in_cnx->key_available = 1;
     new_channel_in_cnx->latest_key_sequence_available = aead->key_seq_number;
 
     return bytes;
+}
+
+const uint8_t* picoquic_skip_mc_key_frame(const uint8_t* bytes, const uint8_t* bytes_max)
+{
+    uint8_t ch_id_length = 0;
+    uint64_t secret_length = 0;
+
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &ch_id_length)) != NULL && // channel id length
+        (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, (uint64_t)ch_id_length)) != NULL && // channel id
+        (bytes = picoquic_frames_varint_skip(bytes, bytes_max)) != NULL && // key seq number
+        (bytes = picoquic_frames_varint_skip(bytes, bytes_max)) != NULL && // from packet number
+        (bytes = picoquic_frames_varint_decode(bytes, bytes_max, &secret_length)) != NULL) { // secret length
+            bytes = picoquic_frames_fixed_skip(bytes, bytes_max, secret_length); // secret
+        }
+
+    return bytes;
+}
+
+int picoquic_process_ack_of_mc_key_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
+    size_t bytes_size, size_t* consumed)
+{
+    const uint8_t* bytes_first = bytes;
+    const uint8_t* bytes_max = bytes + bytes_size;
+    const uint8_t* bytes_after_ftype = bytes = picoquic_frames_varint_skip(bytes, bytes + bytes_size);
+
+    uint8_t id_len;
+    picoquic_multicast_channel_id_t channel_id;
+
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &id_len)) == NULL) {
+        return -1;
+    }
+
+    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes, id_len, &channel_id);
+
+    if (bytes_copied == 0) {
+        return -1;
+    }
+
+    int ret = 0;
+    const uint8_t* bytes_next = picoquic_skip_mc_key_frame(bytes_after_ftype, bytes_max);
+
+    if (bytes_next == NULL) {
+        ret = -1;
+    }
+    else {
+        picoquic_mc_channel_in_cnx_t* ch_in_cnx = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx);
+        ch_in_cnx->key_acked = 1;
+        *consumed = bytes_next - bytes_first;
+    }
+
+    fprintf(stdout, "ACK of MC_KEY sucessfully processed\n");
+
+    return ret;
+}
+
+int picoquic_check_mc_key_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes, const uint8_t* bytes_max, int* no_need_to_repeat)
+{
+    int ret = 0;
+    const uint8_t* bytes_parsing = bytes;
+    uint8_t id_len;
+    picoquic_multicast_channel_id_t channel_id;
+    *no_need_to_repeat = 0;
+
+    if ((bytes_parsing = picoquic_frames_uint8_decode(bytes_parsing, bytes_max, &id_len)) == NULL) {
+        *no_need_to_repeat = 1;
+        return -1;
+    }
+
+    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes_parsing, id_len, &channel_id);
+
+    if (bytes_copied == 0) {
+        *no_need_to_repeat = 1;
+        return -1;
+    }
+
+    picoquic_mc_channel_in_cnx_t* ch_in_cnx;
+
+    if ((ch_in_cnx = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx)) == NULL) {
+        /* If the channel is not in the connection (anymore?), no need to repeat this frame. */
+        *no_need_to_repeat = 1;
+    }
+    else if (ch_in_cnx->state >= 15 || ch_in_cnx->key_acked == 1) {
+        /* If latest MC_KEY was acked or client left the channel or intends to leave it, do not repeat */
+        *no_need_to_repeat = 1;
+    }
+
+    if (*no_need_to_repeat == 0) {
+        fprintf(stdout, "MC_KEY needs repeat\n");
+    } else {
+        fprintf(stdout, "MC_KEY do not need repeat\n");
+    }
+
+    return ret;
 }
 
 /* BDP frames as defined in https://tools.ietf.org/html/draft-kuhn-quic-0rtt-bdp-09
@@ -6982,7 +7202,7 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, picoquic_path_t * path_x, const 
 
                             // CLEAN MC: Refactor event/error logging to qlog
                             if (bytes != NULL) {
-                                picoquic_multicast_channel_t* channel = cnx->mc_channels[0]->channel;
+                                picoquic_multicast_channel_t* channel = cnx->mc_channels[cnx->nb_mc_channels-1]->channel;
                                 fprintf(stdout, "Got MC_ANNOUNCE frame for channel id ");
                                 print_hex_bytes(channel->channel_id.id, channel->channel_id.id_len);
 
@@ -7006,6 +7226,28 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, picoquic_path_t * path_x, const 
                                 fprintf(stdout, "ERROR: bytes == NULL after decoding MC_ANNOUNCE frame\n");
                             }
 
+                            break;
+
+                        case picoquic_frame_type_mc_key: 
+                            bytes = picoquic_decode_mc_key_frame(cnx, bytes, bytes_max); 
+                            ack_needed = 1;
+
+                            // CLEAN MC: Refactor event/error logging to qlog
+                            if (bytes != NULL) {
+                                picoquic_multicast_channel_t* channel = cnx->mc_channels[cnx->nb_mc_channels-1]->channel;
+
+                                picoquic_multicast_aead_secret_t* aead = channel->aead_secrets[channel->nb_aead_secrets-1];
+                                fprintf(stdout, "Got MC_KEY frame for channel id ");
+                                print_hex_bytes(channel->channel_id.id, channel->channel_id.id_len);
+
+                                fprintf(stdout, "\n -- Key Sequence number: %lu\n", aead->key_seq_number);
+                                fprintf(stdout, " -- From Packet number: %lu\n", aead->from_pkt_number);
+                                fprintf(stdout, " -- Secret length: %lu\n", aead->secret_len);
+                            } 
+                            if (bytes == NULL) {
+                                fprintf(stdout, "ERROR: bytes == NULL after decoding MC_KEY frame\n");
+                            }
+                            
                             break;
                         default:
                             /* Not implemented yet! */
@@ -7332,6 +7574,15 @@ int picoquic_skip_frame(const uint8_t* bytes, size_t bytes_maxsize, size_t* cons
                 case picoquic_frame_type_observed_address_v4:
                 case picoquic_frame_type_observed_address_v6:
                     bytes = picoquic_skip_observed_address_frame(bytes, bytes_max, frame_id64);
+                    *pure_ack = 0;
+                    break;
+                case picoquic_frame_type_mc_announce_v4:
+                case picoquic_frame_type_mc_announce_v6:
+                    bytes = picoquic_skip_mc_announce_frame(bytes, bytes_max, frame_id64);
+                    *pure_ack = 0;
+                    break;
+                case picoquic_frame_type_mc_key:
+                    bytes = picoquic_skip_mc_key_frame(bytes, bytes_max);
                     *pure_ack = 0;
                     break;
                 default:

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -264,7 +264,7 @@ typedef struct st_picoquic_multicast_header_secret_t {
 typedef struct st_picoquic_multicast_aead_secret_t {
     uint8_t secret[48]; // max support is SHA-384 (no SHA-512 for now)
     uint64_t secret_len;
-    uint64_t key_seq_number;
+    uint64_t key_seq_number; // starts at 0
     uint64_t from_pkt_number;
 } picoquic_multicast_aead_secret_t;
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -166,7 +166,8 @@ typedef enum {
     picoquic_frame_type_observed_address_v4 = 0x9f81a6,
     picoquic_frame_type_observed_address_v6 = 0x9f81a7,
     picoquic_frame_type_mc_announce_v4 = 0xff3e811,
-    picoquic_frame_type_mc_announce_v6 = 0xff3e812
+    picoquic_frame_type_mc_announce_v6 = 0xff3e812,
+    picoquic_frame_type_mc_key = 0xff3e801
 } picoquic_frame_type_enum_t;
 
 /* PMTU discovery requirement status */
@@ -615,12 +616,12 @@ typedef struct st_picoquic_multicast_channel_t {
     uint16_t header_protection_algorithm;
     uint16_t aead_algorithm;
     picoquic_multicast_header_secret_t header_secret;
-    picoquic_multicast_aead_secret_t aead_secret;
+    picoquic_multicast_aead_secret_t ** aead_secrets;
+    int nb_aead_secrets;
     uint16_t hash_algorithm;
     uint64_t max_rate;
     uint64_t max_ack_delay;
     int is_retired;
-    picoquic_cnx_t ** joined_cnx;
 } picoquic_multicast_channel_t;
 
 // State of a multicast channel in a cnx (with buffers for extensions):
@@ -669,7 +670,8 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     picoquic_multicast_channel_t* channel;
     picoquic_mc_state_enum state;
     picoquic_mc_state_reason_enum state_reason;
-    unsigned int key_available;
+    uint64_t latest_key_sequence_available;
+    int key_available;
 } picoquic_mc_channel_in_cnx_t;
 
 
@@ -2124,6 +2126,9 @@ void picoquic_update_peer_addr(picoquic_path_t* path_x, const struct sockaddr* p
 
 uint8_t* picoquic_format_mc_announce_frame(uint8_t* bytes, const uint8_t* bytes_max, 
     picoquic_multicast_channel_t* channel, picoquic_path_t* path_x, int * more_data);
+
+const uint8_t* picoquic_format_mc_key_frame(uint8_t* bytes, uint8_t* bytes_max, 
+    picoquic_multicast_channel_t* channel, picoquic_multicast_aead_secret_t* aead, int* more_data);
 
 int picoquic_skip_frame(const uint8_t* bytes, size_t bytes_max, size_t* consumed, int* pure_ack);
 const uint8_t* picoquic_skip_path_abandon_frame(const uint8_t* bytes, const uint8_t* bytes_max);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -671,9 +671,17 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     picoquic_mc_state_enum state;
     picoquic_mc_state_reason_enum state_reason;
     uint64_t latest_key_sequence_available;
+    int mc_announce_acked;
+    int mc_join_acked;
+    int mc_leave_acked;
+    int mc_retire_acked;
+    int mc_state_joined_acked;
+    int mc_state_left_acked;
+    int mc_state_declined_join_acked;
+    int mc_state_retired_acked;
     int key_available;
+    int key_acked;
 } picoquic_mc_channel_in_cnx_t;
-
 
 /* QUIC context, defining the tables of connections,
  * open sockets, etc.
@@ -2124,10 +2132,12 @@ uint8_t* picoquic_prepare_observed_address_frame(uint8_t* bytes, const uint8_t* 
     int* more_data, int* is_pure_ack);
 void picoquic_update_peer_addr(picoquic_path_t* path_x, const struct sockaddr* peer_addr);
 
-uint8_t* picoquic_format_mc_announce_frame(uint8_t* bytes, const uint8_t* bytes_max, 
+picoquic_mc_channel_in_cnx_t* picoquic_find_multicast_channel_in_cnx(picoquic_multicast_channel_id_t * ch_id, picoquic_cnx_t* cnx);
+
+uint8_t* picoquic_format_mc_announce_frame(uint8_t* bytes, uint8_t* bytes_max, 
     picoquic_multicast_channel_t* channel, picoquic_path_t* path_x, int * more_data);
 
-const uint8_t* picoquic_format_mc_key_frame(uint8_t* bytes, uint8_t* bytes_max, 
+uint8_t* picoquic_format_mc_key_frame(uint8_t* bytes, uint8_t* bytes_max, 
     picoquic_multicast_channel_t* channel, picoquic_multicast_aead_secret_t* aead, int* more_data);
 
 int picoquic_skip_frame(const uint8_t* bytes, size_t bytes_max, size_t* consumed, int* pure_ack);

--- a/picoquic/picoquic_utils.h
+++ b/picoquic/picoquic_utils.h
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "picoquic.h"
+#include "picoquic_internal.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -90,7 +91,7 @@ uint8_t picoquic_format_connection_id(uint8_t* bytes, size_t bytes_max, picoquic
 uint8_t picoquic_parse_connection_id(const uint8_t* bytes, uint8_t len, picoquic_connection_id_t *cnx_id);
 uint8_t picoquic_format_multicast_channel_id(uint8_t* bytes, size_t bytes_max, picoquic_multicast_channel_id_t ch_id);
 uint8_t picoquic_parse_multicast_channel_id(const uint8_t * bytes, uint8_t len, picoquic_multicast_channel_id_t * ch_id);
-int picoquic_multicast_channel_id_exists_in_cnx(picoquic_multicast_channel_id_t * ch_id, picoquic_cnx_t* cnx);
+struct picoquic_mc_channel_in_cnx_t* picoquic_find_multicast_channel_in_cnx(picoquic_multicast_channel_id_t * ch_id, picoquic_cnx_t* cnx);
 int picoquic_is_connection_id_null(const picoquic_connection_id_t * cnx_id);
 int picoquic_compare_connection_id(const picoquic_connection_id_t * cnx_id1, const picoquic_connection_id_t * cnx_id2);
 uint64_t picoquic_connection_id_hash(const picoquic_connection_id_t * cid, const uint8_t * hash_seed);

--- a/picoquic/picoquic_utils.h
+++ b/picoquic/picoquic_utils.h
@@ -91,7 +91,6 @@ uint8_t picoquic_format_connection_id(uint8_t* bytes, size_t bytes_max, picoquic
 uint8_t picoquic_parse_connection_id(const uint8_t* bytes, uint8_t len, picoquic_connection_id_t *cnx_id);
 uint8_t picoquic_format_multicast_channel_id(uint8_t* bytes, size_t bytes_max, picoquic_multicast_channel_id_t ch_id);
 uint8_t picoquic_parse_multicast_channel_id(const uint8_t * bytes, uint8_t len, picoquic_multicast_channel_id_t * ch_id);
-struct picoquic_mc_channel_in_cnx_t* picoquic_find_multicast_channel_in_cnx(picoquic_multicast_channel_id_t * ch_id, picoquic_cnx_t* cnx);
 int picoquic_is_connection_id_null(const picoquic_connection_id_t * cnx_id);
 int picoquic_compare_connection_id(const picoquic_connection_id_t * cnx_id1, const picoquic_connection_id_t * cnx_id2);
 uint64_t picoquic_connection_id_hash(const picoquic_connection_id_t * cid, const uint8_t * hash_seed);

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -901,6 +901,20 @@ static void picoquic_create_random_mc_channel_id(picoquic_quic_t* quic, picoquic
     channel_id->id_len = id_length;
 }
 
+picoquic_mc_channel_in_cnx_t* picoquic_find_multicast_channel_in_cnx(picoquic_multicast_channel_id_t * ch_id, picoquic_cnx_t* cnx)
+{
+    for (int i = 0; i < cnx->nb_mc_channels; i++) {
+        picoquic_mc_channel_in_cnx_t* channel = cnx->mc_channels[i];
+        int len = (int) channel->channel->channel_id.id_len < (int) ch_id->id_len ? (int) channel->channel->channel_id.id_len : (int) ch_id->id_len;
+        
+        if (memcmp(channel->channel->channel_id.id, ch_id->id, len) == 0) {
+            return channel;
+        }
+    }
+
+    return NULL;
+}
+
 int picoquic_create_multicast_channel(picoquic_quic_t* quic, picoquic_multicast_channel_t** mc_channel, int max_clients, 
     struct sockaddr_storage* group_ipv4, struct sockaddr_storage* group_ipv6) 
 {
@@ -915,6 +929,7 @@ int picoquic_create_multicast_channel(picoquic_quic_t* quic, picoquic_multicast_
     }
 
     picoquic_multicast_channel_t* new_channel = malloc(sizeof(picoquic_multicast_channel_t));
+    memset(new_channel, 0, sizeof(picoquic_multicast_channel_t));
     if (new_channel == NULL) {
         fprintf(stderr, "could not create multicast channel: malloc failed\n");
         return -1;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -983,7 +983,7 @@ int picoquic_schedule_mc_announce_and_join(picoquic_cnx_t* cnx, picoquic_multica
         return -1;
     }
 
-    if (picoquic_multicast_channel_id_exists_in_cnx(&channel->channel_id, cnx) != 0) {
+    if (picoquic_find_multicast_channel_in_cnx(&channel->channel_id, cnx) != NULL) {
         fprintf(stderr, "could not schedule multicast announce and join: channel was already added to connection\n");
         return -1;
     }

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2894,8 +2894,9 @@ uint8_t * picoquic_prepare_multicast_init_frames(picoquic_cnx_t* cnx, picoquic_p
         // send MC_KEY of latest AEAD key if no key was sent on this cnx yet
         if (ch->key_available < 1 && ch->latest_key_sequence_available == 0 && ch->channel->nb_aead_secrets > 0) {
             int key_sequence_number = ch->channel->nb_aead_secrets - 1;
+            picoquic_multicast_aead_secret_t* aead = ch->channel->aead_secrets[ch->channel->nb_aead_secrets-1];
 
-            uint8_t *bytes_next = picoquic_format_mc_key_frame(bytes, bytes_max, ch->channel, key_sequence_number, more_data);
+            uint8_t *bytes_next = picoquic_format_mc_key_frame(bytes, bytes_max, ch->channel, aead, more_data);
             if (bytes_next > bytes) {
                 *is_pure_ack = 0;
                 bytes = bytes_next;

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2882,7 +2882,7 @@ uint8_t * picoquic_prepare_multicast_init_frames(picoquic_cnx_t* cnx, picoquic_p
         picoquic_mc_channel_in_cnx_t* ch = cnx->mc_channels[i];
 
         // if in state "announce_scheduled"
-        if (ch->state < 2 && !cnx->client_mode) {
+        if (ch->state < 2) {
             uint8_t *bytes_next = picoquic_format_mc_announce_frame(bytes, bytes_max, ch->channel, path_x, more_data);
             if (bytes_next > bytes) {
                 *is_pure_ack = 0;
@@ -2890,15 +2890,21 @@ uint8_t * picoquic_prepare_multicast_init_frames(picoquic_cnx_t* cnx, picoquic_p
                 ch->state = 2; // "announced"
             }
         }
-        // TODO MC: Implement Format MC_KEY and MC_JOIN frame
-        // if (ch->key_available == 0) {
-        //     uint8_t *bytes_next = picoquic_format_mc_key_frame(bytes, bytes_max, ch->channel, more_data);
-        //     if (bytes_next > bytes) {
-        //         *is_pure_ack = 0;
-        //         bytes = bytes_next;
-        //         ch->key_available = 1;
-        //     }
-        // }
+        
+        // send MC_KEY of latest AEAD key if no key was sent on this cnx yet
+        if (ch->key_available < 1 && ch->latest_key_sequence_available == 0 && ch->channel->nb_aead_secrets > 0) {
+            int key_sequence_number = ch->channel->nb_aead_secrets - 1;
+
+            uint8_t *bytes_next = picoquic_format_mc_key_frame(bytes, bytes_max, ch->channel, key_sequence_number, more_data);
+            if (bytes_next > bytes) {
+                *is_pure_ack = 0;
+                bytes = bytes_next;
+                ch->key_available = 1;
+                ch->latest_key_sequence_available = key_sequence_number;
+            }
+        }
+        
+        // TODO MC: Implement Format MC_JOIN frame
         // if (ch->state < 5) {
         //     uint8_t *bytes_next = picoquic_format_mc_join_frame(bytes, bytes_max, ch->channel, more_data);
         //     if (bytes_next > bytes) {
@@ -3648,7 +3654,7 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
                     }
 
                     // TODO MC: Maybe also include this in almost_ready
-                    if (cnx->is_multicast_enabled) {
+                    if (cnx->is_multicast_enabled && !cnx->client_mode) {
                         /* If required, prepare multicast announce, key and join frames. */
                         bytes_next = picoquic_prepare_multicast_init_frames(cnx, path_x,
                         bytes_next, bytes_max, &more_data, &is_pure_ack,

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1421,11 +1421,19 @@ static int picoquic_compute_initial_secrets(picoquic_quic_t * quic, int version_
     return ret;
 }
 
+/* 
+ * Initial computation of Header secret and AEAD secret 
+ */
 int picoquic_compute_multicast_secrets(picoquic_quic_t * quic, picoquic_multicast_channel_t* channel)
 {
     int ret = 0;
     ptls_iovec_t salt;
     size_t rand_bytes_length = quic->local_cnxid_length;
+
+    if (channel->nb_aead_secrets > 0 || &channel->header_secret.secret != NULL) {
+        fprintf(stdout, "Error while computing initial multicast secrets: Already available\n");
+        return -1;
+    }
 
     // always use salt from QUIC v2 in multicast channels for now
     int version_index = picoquic_get_version_index(PICOQUIC_V2_VERSION);
@@ -1450,21 +1458,40 @@ int picoquic_compute_multicast_secrets(picoquic_quic_t * quic, picoquic_multicas
     uint8_t rand_bytes_aead[rand_bytes_length];
     picoquic_crypto_random(quic, rand_bytes_aead, rand_bytes_length);
 
+    picoquic_multicast_aead_secret_t* new_aead_secret = malloc(sizeof(picoquic_multicast_aead_secret_t));
+    if (new_aead_secret == NULL) {
+        fprintf(stderr, "could not create picoquic_multicast_aead_secret_t: malloc failed\n");
+        return -1;
+    }
+
+    picoquic_multicast_aead_secret_t** new_aead_list = (picoquic_multicast_aead_secret_t **)malloc((channel->nb_aead_secrets + 1) * sizeof(picoquic_multicast_aead_secret_t *));
+
+    if (new_aead_list == NULL) {
+        fprintf(stderr, "could not create picoquic_multicast_aead_secret_t list: malloc failed\n");
+        return -1;
+    }
+
+    channel->aead_secrets = new_aead_list;
+    memset(new_aead_secret, 0, sizeof(picoquic_multicast_aead_secret_t));
+    
     ptls_cipher_suite_t* cipher_aead = picoquic_get_cipher_suite_by_id(channel->aead_algorithm, quic->use_low_memory);
-    ret = picoquic_setup_multicast_secret(cipher_aead, salt, rand_bytes_aead, rand_bytes_length, channel->aead_secret.secret);
+    ret = picoquic_setup_multicast_secret(cipher_aead, salt, rand_bytes_aead, rand_bytes_length, new_aead_secret->secret);
 
     if (ret != 0) {
         return ret;
     }
 
     if (channel->aead_algorithm == PICOQUIC_AES_256_GCM_SHA384) {
-        channel->aead_secret.secret_len = 48;
+        new_aead_secret->secret_len = 48;
     } else if (channel->aead_algorithm == PICOQUIC_AES_128_GCM_SHA256) {
-        channel->aead_secret.secret_len = 32;    
+        new_aead_secret->secret_len = 32;    
     }
 
-    channel->aead_secret.key_seq_number = 0;
-    channel->aead_secret.from_pkt_number = 0;
+    new_aead_secret->key_seq_number = 0;
+    new_aead_secret->from_pkt_number = 0;
+
+    channel->aead_secrets[channel->nb_aead_secrets] = new_aead_secret;
+    channel->nb_aead_secrets++;
 
     return ret;
 }

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1430,7 +1430,7 @@ int picoquic_compute_multicast_secrets(picoquic_quic_t * quic, picoquic_multicas
     ptls_iovec_t salt;
     size_t rand_bytes_length = quic->local_cnxid_length;
 
-    if (channel->nb_aead_secrets > 0 || &channel->header_secret.secret != NULL) {
+    if (channel->nb_aead_secrets > 0 || channel->header_secret.secret_len > 0) {
         fprintf(stdout, "Error while computing initial multicast secrets: Already available\n");
         return -1;
     }

--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -432,18 +432,18 @@ uint8_t picoquic_parse_multicast_channel_id(const uint8_t * bytes, uint8_t len, 
     return len;
 }
 
-int picoquic_multicast_channel_id_exists_in_cnx(picoquic_multicast_channel_id_t * ch_id, picoquic_cnx_t* cnx)
+picoquic_mc_channel_in_cnx_t* picoquic_find_multicast_channel_in_cnx(picoquic_multicast_channel_id_t * ch_id, picoquic_cnx_t* cnx)
 {
     for (int i = 0; i < cnx->nb_mc_channels; i++) {
         picoquic_mc_channel_in_cnx_t* channel = cnx->mc_channels[i];
         int len = (int) channel->channel->channel_id.id_len < (int) ch_id->id_len ? (int) channel->channel->channel_id.id_len : (int) ch_id->id_len;
         
         if (memcmp(channel->channel->channel_id.id, ch_id->id, len) == 0) {
-            return 1;
+            return channel;
         }
     }
 
-    return 0;
+    return NULL;
 }
 
 /* Hash function for addresses. */

--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -432,20 +432,6 @@ uint8_t picoquic_parse_multicast_channel_id(const uint8_t * bytes, uint8_t len, 
     return len;
 }
 
-picoquic_mc_channel_in_cnx_t* picoquic_find_multicast_channel_in_cnx(picoquic_multicast_channel_id_t * ch_id, picoquic_cnx_t* cnx)
-{
-    for (int i = 0; i < cnx->nb_mc_channels; i++) {
-        picoquic_mc_channel_in_cnx_t* channel = cnx->mc_channels[i];
-        int len = (int) channel->channel->channel_id.id_len < (int) ch_id->id_len ? (int) channel->channel->channel_id.id_len : (int) ch_id->id_len;
-        
-        if (memcmp(channel->channel->channel_id.id, ch_id->id, len) == 0) {
-            return channel;
-        }
-    }
-
-    return NULL;
-}
-
 /* Hash function for addresses. */
 
 size_t picoquic_hash_addr_bytes(const struct sockaddr* addr, uint8_t* bytes)


### PR DESCRIPTION
- Fix implementation of `MC_ANNOUNCE` frame decoding and encoding
- Implement `MC_KEY` frame incl. state handling
- Add necessary methods to process ACKs and check if retransmission is necessary for `MC_ANNOUNCE` and `MC_KEY`