### PR TITLE
Multicast/Reformat State Handling

### DIFF
--- a/multicast_sample/multicast_client.c
+++ b/multicast_sample/multicast_client.c
@@ -549,6 +549,11 @@ int multicast_client_callback(picoquic_cnx_t *cnx,
             fprintf(stdout, "app: Connection to the server confirmed.\n");
 
             break;
+        case picoquic_callback_multicast_join_possible:
+            fprintf(stdout, "App: Multicast join possible\n");
+            picoquic_multicast_channel_id_t *ch_id = (picoquic_multicast_channel_id_t *)v_stream_ctx;
+            ret = picoquic_join_mc_channel(cnx, ch_id); // For now, always accept join request by server
+            break;
         default:
             /* unexpected -- just ignore. */
             break;

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -6475,7 +6475,7 @@ const uint8_t* picoquic_decode_mc_announce_frame(picoquic_cnx_t* cnx, const uint
         }
     }
     
-    new_channel_in_cnx->state = 2; // "announced"
+    new_channel_in_cnx->state = picoquic_mc_state_announced; 
 
     return bytes;
 }
@@ -6569,7 +6569,7 @@ int picoquic_check_mc_announce_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* 
         /* If the channel is not in the connection (anymore?), no need to repeat this frame. */
         *no_need_to_repeat = 1;
     }
-    else if (ch_in_cnx->state >= 15 || ch_in_cnx->mc_announce_acked == 1) {
+    else if (ch_in_cnx->state >= picoquic_mc_state_leave_pending || ch_in_cnx->mc_announce_acked > 0) {
         /* If MC_ANNOUNCE was acked or client left the channel or intends to leave it, do not repeat */
         *no_need_to_repeat = 1;
     }
@@ -6826,7 +6826,7 @@ int picoquic_check_mc_key_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes
         /* If the channel is not in the connection (anymore?), no need to repeat this frame. */
         *no_need_to_repeat = 1;
     }
-    else if (ch_in_cnx->state >= 15 || (ch_in_cnx->key_acked == 1 && ch_in_cnx->latest_key_sequence_acked == ch_in_cnx->latest_key_sequence_available)) {
+    else if (ch_in_cnx->state >= picoquic_mc_state_leave_pending || (ch_in_cnx->key_acked > 0 && ch_in_cnx->latest_key_sequence_acked == ch_in_cnx->latest_key_sequence_available)) {
         /* If latest MC_KEY was acked or client left the channel or intends to leave it, do not repeat */
         *no_need_to_repeat = 1;
     }
@@ -6911,7 +6911,7 @@ uint8_t* picoquic_format_mc_join_frame(uint8_t* bytes, uint8_t* bytes_max, picoq
 
     picoquic_mc_channel_in_cnx_t* channel_found = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx);
 
-    if (channel_found == NULL || channel_found->key_available == 0 || channel_found->state < 2 || channel_found->state >= 25) {
+    if (channel_found == NULL || channel_found->key_available == 0 || channel_found->state < picoquic_mc_state_announced || channel_found->state >= picoquic_mc_state_retire_pending) {
         fprintf(stderr, "Error: Received a MC_JOIN, but no MC_KEY and/or MC_ANNOUNCE was receved, or channel is already retired\n");
         return NULL;
     }
@@ -6937,7 +6937,7 @@ uint8_t* picoquic_format_mc_join_frame(uint8_t* bytes, uint8_t* bytes_max, picoq
         return NULL;
     }
 
-    channel_found->state = 5; // Join pending
+    channel_found->state = picoquic_mc_state_join_pending;
 
     return bytes;
 }
@@ -7019,7 +7019,7 @@ int picoquic_check_mc_join_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* byte
         /* If the channel is not in the connection (anymore?), no need to repeat this frame. */
         *no_need_to_repeat = 1;
     }
-    else if (ch_in_cnx->state >= 10 || ch_in_cnx->mc_join_acked > 0) {
+    else if (ch_in_cnx->state >= picoquic_mc_state_join_confirmed || ch_in_cnx->mc_join_acked > 0) {
         /* If MC_JOIN was already acked or state is "join confirmed" or higher, no need to repeat MC_JOIN */
         *no_need_to_repeat = 1;
     }
@@ -7176,15 +7176,15 @@ const uint8_t* picoquic_decode_mc_state_frame(picoquic_cnx_t* cnx, const uint8_t
         if (reason != picoquic_mc_state_reason_requested_by_server) {
             fprintf(stdout, "Notice: Received MC_STATE(Joined) frame did provide an illegal reason code, ignoring reason code\n");
         }
-        if (channel_found->state >= 5 && channel_found->state < 10) {
+        if (channel_found->state >= picoquic_mc_state_join_pending && channel_found->state < picoquic_mc_state_join_confirmed) {
             // client joins after receiving MC_JOIN frame
             fprintf(stdout, "Got MC_STATE(Joined) from client\n");
-            channel_found->state = 8; // "join attempted"
+            channel_found->state = picoquic_mc_state_join_attempted;
         }
-        else if (channel_found->state >=15 && channel_found->state < 25 && channel_found->mc_join_acked) {
+        else if (channel_found->state >= picoquic_mc_state_leave_pending && channel_found->state < picoquic_mc_state_retire_pending && channel_found->mc_join_acked) {
             // Half-illegal behavior: Leave pending or left, but received MC_JOIN in the past
             fprintf(stdout, "Notice: Client joins multicast channel directly after trying to leave or left\n");
-            channel_found->state = 8; // "join attempted"
+            channel_found->state = picoquic_mc_state_join_attempted;
         } 
         else {
             // ignoring MC_STATE frame 
@@ -7194,15 +7194,15 @@ const uint8_t* picoquic_decode_mc_state_frame(picoquic_cnx_t* cnx, const uint8_t
 
     // MC_STATE(Declined Join)
     if (state == picoquic_mc_state_frame_declined_join) {
-        if (channel_found->state >= 5 && channel_found->state < 8) {
+        if (channel_found->state >= picoquic_mc_state_join_pending && channel_found->state < picoquic_mc_state_join_attempted) {
             // client declines join after receiving MC_JOIN frame
             fprintf(stdout, "Got MC_STATE(Declined Join) from client\n");
-            channel_found->state = 20; // "left"
+            channel_found->state = picoquic_mc_state_left; 
         }
-        else if (channel_found->state >= 8 && channel_found->state < 15) {
+        else if (channel_found->state >= picoquic_mc_state_join_attempted && channel_found->state < picoquic_mc_state_leave_pending) {
             // Half-illegal behavior: Client already in Join attempted or join confirmed
             fprintf(stdout, "Notice: Client declined joining multicast channel after confirming join. Let client leave the channel.\n");
-            channel_found->state = 20; // "left"
+            channel_found->state = picoquic_mc_state_left; 
         } 
         else {
             // ignoring MC_STATE frame 
@@ -7212,10 +7212,10 @@ const uint8_t* picoquic_decode_mc_state_frame(picoquic_cnx_t* cnx, const uint8_t
 
     // MC_STATE(Left)
     if (state == picoquic_mc_state_frame_left) {
-        if (channel_found->state >= 5 && channel_found->state < 20) {
+        if (channel_found->state >= 5 && channel_found->state < picoquic_mc_state_left) {
             // client leaves a non-retired channel after join request by server
             fprintf(stdout, "Got MC_STATE(Leave) from client\n");
-            channel_found->state = 20; // "left"
+            channel_found->state = picoquic_mc_state_left; 
         }
         else {
             // ignoring MC_STATE frame 
@@ -7228,10 +7228,10 @@ const uint8_t* picoquic_decode_mc_state_frame(picoquic_cnx_t* cnx, const uint8_t
         if (reason != picoquic_mc_state_reason_requested_by_server) {
             fprintf(stdout, "Notice: Received MC_STATE(Retired) frame did provide an illegal reason code, ignoring reason code\n");
         }
-        if (channel_found->state >= 25 && channel_found->state < 30) {
+        if (channel_found->state >= picoquic_mc_state_retire_pending && channel_found->state < picoquic_mc_state_retired) {
             // client confirms retired channel
             fprintf(stdout, "Got MC_STATE(Retired) from client\n");
-            channel_found->state = 30; // "retired"
+            channel_found->state = picoquic_mc_state_retired;
         }
         else {
             // ignoring MC_STATE frame 

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -332,7 +332,10 @@ typedef enum {
     picoquic_callback_path_quality_changed, /* Some path quality parameters have changed */
     picoquic_callback_path_address_observed, /* The peer has reported an address for the path */
     picoquic_callback_app_wakeup, /* wakeup timer set by application has expired */
-    picoquic_callback_next_path_allowed /* There are enough path_id and connection ID available for the next path */
+    picoquic_callback_next_path_allowed, /* There are enough path_id and connection ID available for the next path */
+    picoquic_callback_multicast_join_possible, /* MC_JOIN frame has been received and client is able to join */
+    picoquic_callback_multicast_stream_data, /* Stream frame has been received over multicast */
+    picoquic_callback_multicast_datagram, /* Datagram frame has been received over multicast */
 } picoquic_call_back_event_t;
 
 typedef struct st_picoquic_tp_prefered_address_t {
@@ -735,6 +738,9 @@ int picoquic_create_multicast_channel(picoquic_quic_t* quic, picoquic_multicast_
 
 /* Prepare MC_ANNOUNCE, MC_KEY and MC_JOIN frame and queue sending to client */
 int picoquic_schedule_mc_announce_and_join(picoquic_cnx_t* cnx, picoquic_multicast_channel_t* channel);
+
+/* Send MC_STATE(Joined) to server */
+int picoquic_join_mc_channel(picoquic_cnx_t* cnx, picoquic_multicast_channel_id_t* ch_id);
 
 /* Set the Address Discovery mode for the context */
 void picoquic_set_default_address_discovery_mode(picoquic_quic_t* quic, int mode);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -691,6 +691,9 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     uint64_t latest_key_sequence_acked;
 
     // the following is used on client only:
+    picoquic_mc_state_enum state_scheduled;
+    picoquic_mc_state_frame_enum state_frame_scheduled;
+    int state_reason_scheduled;         // reason code for scheduled state frame, could also be different from picoquic_mc_state_reason_enum choices
     int mc_state_acked;                 // At least one MC_STATE frame was acked
     int mc_limits_acked;                // At least one MC_LIMITS frame was acked
     uint64_t latest_state_sequence_acked;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1029,6 +1029,19 @@ int picoquic_schedule_mc_announce_and_join(picoquic_cnx_t* cnx, picoquic_multica
     return 0;
 }
 
+int picoquic_join_mc_channel(picoquic_cnx_t* cnx, picoquic_multicast_channel_id_t* ch_id) {
+    picoquic_mc_channel_in_cnx_t* ch_in_cnx = picoquic_find_multicast_channel_in_cnx(ch_id, cnx);
+    if (ch_in_cnx == NULL || ch_in_cnx->state < picoquic_mc_state_join_pending || ch_in_cnx->state >= picoquic_mc_state_retire_pending) {
+        return -1;
+    }
+
+    ch_in_cnx->state_frame_scheduled = picoquic_mc_state_frame_joined;
+    ch_in_cnx->state_scheduled = picoquic_mc_state_join_attempted;
+    ch_in_cnx->state_reason_scheduled = picoquic_mc_state_reason_requested_by_server;
+
+    return 0;
+}
+
 void picoquic_set_default_address_discovery_mode(picoquic_quic_t* quic, int mode)
 {
     if (mode > 0 && mode <= 3) {

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2885,12 +2885,12 @@ uint8_t * picoquic_prepare_multicast_init_frames(picoquic_cnx_t* cnx, picoquic_p
         picoquic_mc_channel_in_cnx_t* ch = cnx->mc_channels[i];
 
         // if in state "announce_scheduled"
-        if (ch->state < 2) {
+        if (ch->state < picoquic_mc_state_announced) {
             uint8_t *bytes_next = picoquic_format_mc_announce_frame(bytes, bytes_max, ch->channel, path_x, more_data);
             if (bytes_next > bytes) {
                 *is_pure_ack = 0;
                 bytes = bytes_next;
-                ch->state = 2; // "announced"
+                ch->state = picoquic_mc_state_announced; 
             }
         }
         
@@ -2909,12 +2909,12 @@ uint8_t * picoquic_prepare_multicast_init_frames(picoquic_cnx_t* cnx, picoquic_p
         }
         
         // Send MC_JOIN frame
-        if (ch->state < 5 && ch->state >= 2 && ch->key_acked > 0 && ch->mc_announce_acked > 0) {
+        if (ch->state < picoquic_mc_state_join_pending && ch->state >= picoquic_mc_state_announced && ch->key_acked > 0 && ch->mc_announce_acked > 0) {
             uint8_t *bytes_next = picoquic_format_mc_join_frame(bytes, bytes_max, ch->channel, cnx, more_data);
             if (bytes_next > bytes) {
                 *is_pure_ack = 0;
                 bytes = bytes_next;
-                ch->state = 5; // "join_pending"
+                ch->state = picoquic_mc_state_join_pending;
             }
         }
     }
@@ -2940,7 +2940,7 @@ uint8_t * picoquic_prepare_multicast_state_frames(picoquic_cnx_t* cnx,
         picoquic_mc_channel_in_cnx_t* ch = cnx->mc_channels[i];
 
         // if in state "join pending" and MC_KEY received -> check if client can join
-        if (ch->state >= 5 && ch->state < 8 && ch->key_available > 0) {
+        if (ch->state >= picoquic_mc_state_join_pending && ch->state < picoquic_mc_state_join_attempted && ch->key_available > 0) {
             nb_channels_join_pending++;
             picoquic_tp_multicast_client_params_t* params = &cnx->local_parameters.multicast_client_params;
 
@@ -2950,22 +2950,35 @@ uint8_t * picoquic_prepare_multicast_state_frames(picoquic_cnx_t* cnx,
                 uint8_t *bytes_next = picoquic_format_mc_state_frame(bytes, bytes_max, ch, more_data,
                     picoquic_frame_type_mc_state_multicast,
                     picoquic_mc_state_frame_declined_join,
-                    picoquic_mc_state_reason_limit_violation);
+                    picoquic_mc_state_reason_property_violation); // TODO MC: If MC_LIMITS is just out of date, use mc_state_reason_unsynchronized_proerties instead
                 if (bytes_next > bytes) {
                     *is_pure_ack = 0;
                     bytes = bytes_next;
-                    ch->state = 20; // "left"
+                    ch->state = picoquic_mc_state_left;
                 }
             } else {
-                // Join possible, sent MC_STATE(JOINED)
+                // Callback to application to decide whether the join should happen or not
+                cnx->callback_fn(cnx, 0, NULL, 0, picoquic_callback_multicast_join_possible, cnx->callback_ctx, &ch->channel->channel_id);
+            }
+            
+            // Send scheduled state frame (e.g. desired by application)
+            if (ch->state_scheduled != 0 && ch->state_frame_scheduled != 0 && ch->state_scheduled != ch->state) {
+                picoquic_frame_type_enum_t ftype = picoquic_frame_type_mc_state_multicast;
+                if (ch->state_reason_scheduled > picoquic_mc_state_reason_limit_violation) {
+                    ftype = picoquic_frame_type_mc_state_application;
+                }
                 uint8_t *bytes_next = picoquic_format_mc_state_frame(bytes, bytes_max, ch, more_data,
-                    picoquic_frame_type_mc_state_multicast,
-                    picoquic_mc_state_frame_joined,
-                    picoquic_mc_state_reason_requested_by_server);
+                    ftype,
+                    ch->state_frame_scheduled,
+                    ch->state_reason_scheduled);
+
                 if (bytes_next > bytes) {
                     *is_pure_ack = 0;
                     bytes = bytes_next;
-                    ch->state = 8; // "join attempted"
+                    ch->state = ch->state_scheduled; 
+                    ch->state_frame_scheduled = 0;
+                    ch->state_reason_scheduled = 0;
+                    ch->state_scheduled = 0;
                 }
             }
         }


### PR DESCRIPTION
- Use callback to application to decide wheter to join the multicast channel or not on server request
- Reformat state context usage to always use enum values instead of integers