### PR TITLE
Multicast/mcrx setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,19 +402,25 @@ if (BUILD_DEMO)
 endif()
 
 if (BUILD_MULTICAST)
+    find_library(LIBMCRX_LIBRARY NAMES libmcrx.a PATHS /usr/lib /usr/local/lib)
+    find_path(LIBMCRX_INCLUDE_DIR NAMES libmcrx.h PATHS /usr/include /usr/local/include)
     add_executable(multicast
         multicast_sample/multicast.c
         multicast_sample/multicast_server.c
         multicast_sample/multicast_client.c
-        multicast_sample/multicast_background.c)
+        multicast_sample/multicast_background.c
+        picoquic/multicast.c)
     target_link_libraries(multicast
         PUBLIC
             ${PTLS_LIBRARIES}
             ${OPENSSL_LIBRARIES}
             ${MBEDTLS_LIBRARIES}
+            ${LIBMCRX_LIBRARY}
             picoquic-log
             picoquic-core
             picohttp-core)
+    target_include_directories(multicast PRIVATE ${LIBMCRX_INCLUDE_DIR})
+    message(STATUS "LIBMCRX_LIBRARY = ${LIBMCRX_LIBRARY}")
     set_picoquic_compile_settings(multicast)
 endif()
 

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -6214,6 +6214,7 @@ picoquic_mc_channel_in_cnx_t* picoquic_add_channel_to_cnx(picoquic_cnx_t* cnx, p
         return NULL;
     }
 
+    // Add channel to cnx struct
     picoquic_mc_channel_in_cnx_t** new_channel_list = (picoquic_mc_channel_in_cnx_t **)malloc((cnx->nb_mc_channels + 1) * sizeof(picoquic_mc_channel_in_cnx_t *));
 
     if (new_channel_list == NULL) { 
@@ -6221,7 +6222,7 @@ picoquic_mc_channel_in_cnx_t* picoquic_add_channel_to_cnx(picoquic_cnx_t* cnx, p
     }
 
     if (cnx->mc_channels != NULL) {
-        memset(new_channel_list, 0, sizeof(picoquic_mc_channel_in_cnx_t*));
+        memset(new_channel_list, 0, (cnx->nb_mc_channels + 1) * sizeof(picoquic_mc_channel_in_cnx_t*));
         if (cnx->nb_mc_channels > 0) {
             memcpy(new_channel_list, cnx->mc_channels, cnx->nb_mc_channels * sizeof(picoquic_mc_channel_in_cnx_t *));
         }
@@ -6234,6 +6235,37 @@ picoquic_mc_channel_in_cnx_t* picoquic_add_channel_to_cnx(picoquic_cnx_t* cnx, p
     new_channel_in_cnx->channel = channel;
     cnx->mc_channels[cnx->nb_mc_channels] = new_channel_in_cnx;
     cnx->nb_mc_channels++;
+
+    // Add channel to quic struct if not available
+    picoquic_quic_t* quic = cnx->quic;
+    int found = 0;
+    for (int i = 0; i < quic->nb_mc_channels; i++) {
+        if (quic->mc_channels[i] == channel) {
+            found = 1;
+        }
+    }
+
+    if (found > 0) {
+        return new_channel_in_cnx;
+    }
+
+    picoquic_multicast_channel_t** new_q_channel_list = (picoquic_multicast_channel_t **)malloc((quic->nb_mc_channels + 1) * sizeof(picoquic_multicast_channel_t *));
+
+    if (new_q_channel_list == NULL) { 
+        return NULL;
+    }
+
+    if (quic->mc_channels != NULL) {
+        memset(new_q_channel_list, 0, (quic->nb_mc_channels + 1) * sizeof(picoquic_multicast_channel_t*));
+        if (quic->nb_mc_channels > 0) {
+            memcpy(new_q_channel_list, quic->mc_channels, quic->nb_mc_channels * sizeof(picoquic_multicast_channel_t *));
+        }
+        free(quic->mc_channels);
+    }
+    quic->mc_channels = new_q_channel_list;
+
+    quic->mc_channels[quic->nb_mc_channels] = channel;
+    quic->nb_mc_channels++;
 
     return new_channel_in_cnx;
 }
@@ -6398,6 +6430,7 @@ const uint8_t* picoquic_decode_mc_announce_frame(picoquic_cnx_t* cnx, const uint
         }
 
         channel->channel_id = channel_id;
+        channel->client_mode = 1;
     }
 
     // if not enough bytes received for two addresses (src and group), then error
@@ -6668,6 +6701,7 @@ const uint8_t* picoquic_decode_mc_key_frame(picoquic_cnx_t* cnx, const uint8_t* 
         }
 
         channel->channel_id = channel_id;
+        channel->client_mode = 1;
     }
 
     picoquic_multicast_aead_secret_t* aead = malloc(sizeof(picoquic_multicast_aead_secret_t));

--- a/picoquic/multicast.c
+++ b/picoquic/multicast.c
@@ -34,6 +34,7 @@
 #endif
 
 /* Call custom do_receive callback function OR mcrx_ctx_receive_packets to receive packets */
+// TODO MC: is this function actually needed? Probably only if mcrx_ctx_set_receive_socket_handlers method does not work
 int picoquic_mcrx_receive_packets(struct mcrx_ctx *ctx, 
     int (*do_receive)(intptr_t handle, int fd), 
     intptr_t* do_handle_val,
@@ -65,9 +66,10 @@ int picoquic_mcrx_added_socket_cb(struct mcrx_ctx* ctx,
     int fd,
     int (*do_receive)(intptr_t handle, int fd)) 
 {
-    // TODO MC: Do somthing here?
+    // TODO MC: Add socket to picoquic_quic context, so that it is included in picoquic_packet_loop_select's select() statement
 
-    // do_receive call maybe not needed (see jake's comment on python-asyncio-taps)
+    // do_receive call maybe not needed?
+    // TODO MC: Figure out how to use the do_receive callback
     do_receive(handle, fd);
     return MCRX_ERR_OK;
 }
@@ -77,30 +79,38 @@ int picoquic_mcrx_removed_socket_cb(
     struct mcrx_ctx* ctx,
     int fd)
 {
-    // TODO MC: Do something here?
+    // TODO MC: Remove socket to picoquic_quic context, so that it is excluded from picoquic_packet_loop_select's select() statement
 
     return MCRX_ERR_OK;
 }
 
 /* Initialize MCRX context and set receive socket handlers */
-int picoquic_mcrx_initialize(struct mcrx_ctx *ctx) 
+int picoquic_mcrx_initialize(struct mcrx_ctx **ctxp) 
 {
-    if (ctx != NULL) {
+    if (*ctxp != NULL) {
+        fprintf(stdout, "Error in picoquic_mcrx_initialize: ctx already created\n");
         return -1;
     }
-    int err = mcrx_ctx_new(&ctx);
-    if (err != 0) {
+    int err = mcrx_ctx_new(ctxp);
+    if (err != 0)  {
+        fprintf(stdout, "Error in picoquic_mcrx_initialize: ctx object could not be created\n");
         return -1;
     }
 
+    struct mcrx_ctx *ctx = *ctxp;
+
     mcrx_ctx_set_log_priority(ctx, MCRX_LOGLEVEL_WARNING);
+    
     
     err = mcrx_ctx_set_receive_socket_handlers(ctx,
         picoquic_mcrx_added_socket_cb, picoquic_mcrx_removed_socket_cb);
-    
+
+    // TODO MC: Maybe add picoquic_quic context to mcrx_ctx userdata for socket add/remove callbacks
+        
     if (err != 0) {
         ctx = mcrx_ctx_unref(ctx);
-        return -1;
+        fprintf(stdout, "Error in picoquic_mcrx_initialize: mcrx_ctx_set_receive_socket_handlers returned error\n");
+        return err;
     }
 
     return 0;
@@ -115,33 +125,40 @@ int picoquic_mcrx_receive_cb(struct mcrx_packet* pkt) {
     uint8_t* data = 0;
     int len = mcrx_packet_get_contents(pkt, &data);
 
-    // TODO MC: Call function to handle incoming data here
-    // int err = handle_data(info->conn, len, data);
-    // if (err != 0) {
-    //     return MCRX_ERR_CALLBACK_FAILED;
-    // }
+    // TODO MC: Figure out how to use this callback (if it is actually called in our setup), maybe call something like `picoquic_incoming_packet_ex` here
 
     return MCRX_RECEIVE_CONTINUE;
 }
 
 /* Join the channel via mcrx */
-int picoquic_mcrx_join(struct mcrx_ctx *ctx, picoquic_mc_channel_in_cnx_t *ch_in_cnx) 
+int picoquic_mcrx_join(struct mcrx_ctx **ctxp, picoquic_mc_channel_in_cnx_t *ch_in_cnx) 
 {
+    struct mcrx_ctx *ctx = *ctxp;
+
     if (ctx == NULL) {
+        fprintf(stdout, "Error in picoquic_mcrx_join: ctx is NULL\n");
         return -1;
     }
 
-    char src_ip[128];
+    char src_ip[128 + 5];
     struct sockaddr* source = (struct sockaddr*) &ch_in_cnx->channel->source_ip;
     picoquic_addr_text(source, src_ip, sizeof(src_ip));
+    strcpy(src_ip, strtok(src_ip, ":"));
 
-    char group_ip[128];
+    char group_ip[128 + 5];
     struct sockaddr* group = (struct sockaddr*) &ch_in_cnx->channel->group_ip;
     picoquic_addr_text(group, group_ip, sizeof(group_ip));
+    strcpy(group_ip, strtok(group_ip, ":"));
 
     int err = 0;
     struct mcrx_subscription_config cfg = MCRX_SUBSCRIPTION_CONFIG_INIT;
     err = mcrx_subscription_config_pton(&cfg, src_ip, group_ip);
+
+    if (err != 0) {
+        fprintf(stdout, "Error in picoquic_mcrx_join while configuring mcrx_subscription: %i\n", err);
+        
+        return -1;
+    }
 
     uint16_t port;
     if (group->sa_family == AF_INET) {
@@ -155,12 +172,14 @@ int picoquic_mcrx_join(struct mcrx_ctx *ctx, picoquic_mc_channel_in_cnx_t *ch_in
     struct mcrx_subscription* sub = 0;
     err = mcrx_subscription_new(ctx, &cfg, &sub);
     if (err != 0) {
+        fprintf(stdout, "Error in picoquic_mcrx_join: subscription object could not be established\n");
         return -1;
     }
 
     picoquic_mcrx_sub_info* subinfo = (picoquic_mcrx_sub_info*)calloc(sizeof(picoquic_mcrx_sub_info), 1);
     if (!subinfo) {
         mcrx_subscription_unref(sub);
+        fprintf(stdout, "Error picoquic_mcrx_join: subinfo could not be alloced\n");
         return -1;
     }
 
@@ -175,6 +194,7 @@ int picoquic_mcrx_join(struct mcrx_ctx *ctx, picoquic_mc_channel_in_cnx_t *ch_in
     if (err != 0) {
         mcrx_subscription_unref(sub);
         free(subinfo);
+        fprintf(stdout, "Error in picoquic_mcrx_join: could not join with subscription object\n");
         return -1;
     }
 
@@ -182,7 +202,8 @@ int picoquic_mcrx_join(struct mcrx_ctx *ctx, picoquic_mc_channel_in_cnx_t *ch_in
 }
 
 /* Unref mcrx context object (and more, if necessary) */
-int picoquic_mcrx_cleanup(struct mcrx_ctx* ctx) {
+int picoquic_mcrx_cleanup(struct mcrx_ctx **ctxp) {
+    struct mcrx_ctx *ctx = *ctxp;
     if (ctx == NULL) {
         return -1;
     }

--- a/picoquic/multicast.c
+++ b/picoquic/multicast.c
@@ -41,7 +41,7 @@ struct picoquic_mcrx_sub_info {
 
 /* Additional user-data stored in mcrx subscription context */
 struct picoquic_mcrx_ctx_info {
-  picoquic_quic_t* quic;
+  picoquic_multicast_channel_t* channel;
 };
 
 /* Call custom do_receive callback function OR mcrx_ctx_receive_packets to receive packets */
@@ -79,15 +79,10 @@ int picoquic_mcrx_added_socket_cb(struct mcrx_ctx* ctx,
 {
     // Add socket to picoquic_quic context, so that it is included in picoquic_packet_loop_select's select() statement
     struct picoquic_mcrx_ctx_info* info = (struct picoquic_mcrx_ctx_info*)mcrx_ctx_get_userdata(ctx);
-    picoquic_quic_t* quicctx = info->quic;
+    picoquic_multicast_channel_t* channel = info->channel;
 
-    if (quicctx->nb_multicast_fds >= PICOQUIC_MAX_MC_SOCKETS) {
-        fprintf(stdout, "Error: Could not add multicast socket to quic ctx, number of possible multicast sockets exceeded (%i)\n", PICOQUIC_MAX_MC_SOCKETS);
-        return -1;
-    }
-
-    quicctx->multicast_fds[quicctx->nb_multicast_fds] = fd;
-    quicctx->nb_multicast_fds++;
+    channel->fd = fd;
+    channel->socket_open = 1;
 
     // do_receive call maybe not needed?
     // TODO MC: Figure out how to use the do_receive callback
@@ -102,34 +97,18 @@ int picoquic_mcrx_removed_socket_cb(
 {
     // Remove socket to picoquic_quic context, so that it is excluded from picoquic_packet_loop_select's select() statement
     struct picoquic_mcrx_ctx_info* info = (struct picoquic_mcrx_ctx_info*)mcrx_ctx_get_userdata(ctx);
-    picoquic_quic_t* quicctx = info->quic;
+    picoquic_multicast_channel_t* channel = info->channel;
     int found = 0;
 
-    for (int i = 0; i < PICOQUIC_MAX_MC_SOCKETS; i++) {
-        if (quicctx->multicast_fds[i] == fd) {
-            found = 1;
-            quicctx->multicast_fds[i] = 0;
-            if (i < PICOQUIC_MAX_MC_SOCKETS - 1) {
-                for (int j = i; j < PICOQUIC_MAX_MC_SOCKETS - 1; j++) {
-                    quicctx->multicast_fds[j] = quicctx->multicast_fds[j + 1];
-                }
-            }
-        }
-    }
-
-    if (found) {
-        quicctx->nb_multicast_fds--;
-    } else {
-        fprintf(stdout, "Info: Socket to be removed from quic ctx not found in quic ctx\n");
-    }
+    channel->fd = 0;
+    channel->socket_open = 0;
 
     fprintf(stdout, "Debug: mcrx_removed_socket_cb called\n");
-
     return MCRX_ERR_OK;
 }
 
 /* Initialize MCRX context and set receive socket handlers */
-int picoquic_mcrx_initialize(struct mcrx_ctx **ctxp, picoquic_quic_t* quicctx) 
+int picoquic_mcrx_initialize(struct mcrx_ctx **ctxp, picoquic_multicast_channel_t* channel) 
 {
     if (*ctxp != NULL) {
         fprintf(stdout, "Error in picoquic_mcrx_initialize: ctx already created\n");
@@ -148,7 +127,7 @@ int picoquic_mcrx_initialize(struct mcrx_ctx **ctxp, picoquic_quic_t* quicctx)
         return -1;
     }
 
-    info->quic = quicctx;
+    info->channel = channel;
 
     mcrx_ctx_set_userdata(ctx, (intptr_t)info);
     mcrx_ctx_set_log_priority(ctx, MCRX_LOGLEVEL_WARNING);

--- a/picoquic/multicast.c
+++ b/picoquic/multicast.c
@@ -1,0 +1,209 @@
+
+/*
+* Author: Christian Huitema
+* Copyright (c) 2017, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "picoquic.h"
+#include "picoquic_internal.h"
+#include "picoquic_utils.h"
+#include "tls_api.h"
+#include <stdlib.h>
+#include <string.h>
+#include <mcrx/libmcrx.h>
+#ifndef _WINDOWS
+#include <sys/time.h>
+#include <time.h>
+#include <errno.h>
+#endif
+
+/* Call custom do_receive callback function OR mcrx_ctx_receive_packets to receive packets */
+int picoquic_mcrx_receive_packets(struct mcrx_ctx *ctx, 
+    int (*do_receive)(intptr_t handle, int fd), 
+    intptr_t* do_handle_val,
+    int fd) 
+{
+    if (ctx == NULL) {
+        return -1;
+    }
+
+    int ret;
+    if (do_receive != NULL)  {
+        ret = (*do_receive)(*do_handle_val, fd);
+    } else {
+        ret = mcrx_ctx_receive_packets(ctx);
+    }
+
+    if (ret != MCRX_ERR_OK &&
+        ret != MCRX_ERR_NOTHING_JOINED &&
+        ret != MCRX_ERR_TIMEDOUT) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/* Callback called by mcrx when socket was added */
+int picoquic_mcrx_added_socket_cb(struct mcrx_ctx* ctx,
+    intptr_t handle,
+    int fd,
+    int (*do_receive)(intptr_t handle, int fd)) 
+{
+    // TODO MC: Do somthing here?
+
+    // do_receive call maybe not needed (see jake's comment on python-asyncio-taps)
+    do_receive(handle, fd);
+    return MCRX_ERR_OK;
+}
+
+/* Callback called by mcrx when socket was removed */
+int picoquic_mcrx_removed_socket_cb(
+    struct mcrx_ctx* ctx,
+    int fd)
+{
+    // TODO MC: Do something here?
+
+    return MCRX_ERR_OK;
+}
+
+/* Initialize MCRX context and set receive socket handlers */
+int picoquic_mcrx_initialize(struct mcrx_ctx *ctx) 
+{
+    if (ctx != NULL) {
+        return -1;
+    }
+    int err = mcrx_ctx_new(&ctx);
+    if (err != 0) {
+        return -1;
+    }
+
+    mcrx_ctx_set_log_priority(ctx, MCRX_LOGLEVEL_WARNING);
+    
+    err = mcrx_ctx_set_receive_socket_handlers(ctx,
+        picoquic_mcrx_added_socket_cb, picoquic_mcrx_removed_socket_cb);
+    
+    if (err != 0) {
+        ctx = mcrx_ctx_unref(ctx);
+        return -1;
+    }
+
+    return 0;
+}
+
+/* Callback called by mcrx to handle received packets */
+int picoquic_mcrx_receive_cb(struct mcrx_packet* pkt) {
+    struct mcrx_subscription* sub = mcrx_packet_get_subscription(pkt);
+    picoquic_mcrx_sub_info* info = (picoquic_mcrx_sub_info*)mcrx_subscription_get_userdata(sub);
+
+    info->nb_packets++;
+    uint8_t* data = 0;
+    int len = mcrx_packet_get_contents(pkt, &data);
+
+    // TODO MC: Call function to handle incoming data here
+    // int err = handle_data(info->conn, len, data);
+    // if (err != 0) {
+    //     return MCRX_ERR_CALLBACK_FAILED;
+    // }
+
+    return MCRX_RECEIVE_CONTINUE;
+}
+
+/* Join the channel via mcrx */
+int picoquic_mcrx_join(struct mcrx_ctx *ctx, picoquic_mc_channel_in_cnx_t *ch_in_cnx) 
+{
+    if (ctx == NULL) {
+        return -1;
+    }
+
+    char src_ip[128];
+    struct sockaddr* source = (struct sockaddr*) &ch_in_cnx->channel->source_ip;
+    picoquic_addr_text(source, src_ip, sizeof(src_ip));
+
+    char group_ip[128];
+    struct sockaddr* group = (struct sockaddr*) &ch_in_cnx->channel->group_ip;
+    picoquic_addr_text(group, group_ip, sizeof(group_ip));
+
+    int err = 0;
+    struct mcrx_subscription_config cfg = MCRX_SUBSCRIPTION_CONFIG_INIT;
+    err = mcrx_subscription_config_pton(&cfg, src_ip, group_ip);
+
+    uint16_t port;
+    if (group->sa_family == AF_INET) {
+        port = ((struct sockaddr_in*)group)->sin_port;
+    } else {
+        port = ((struct sockaddr_in6*)group)->sin6_port;
+    }
+
+    cfg.port = port;
+
+    struct mcrx_subscription* sub = 0;
+    err = mcrx_subscription_new(ctx, &cfg, &sub);
+    if (err != 0) {
+        return -1;
+    }
+
+    picoquic_mcrx_sub_info* subinfo = (picoquic_mcrx_sub_info*)calloc(sizeof(picoquic_mcrx_sub_info), 1);
+    if (!subinfo) {
+        mcrx_subscription_unref(sub);
+        return -1;
+    }
+
+    subinfo->ch_in_cnx = ch_in_cnx;
+
+    mcrx_subscription_set_receive_cb(sub, picoquic_mcrx_receive_cb);
+    mcrx_subscription_set_userdata(sub, (intptr_t)subinfo);
+
+    ch_in_cnx->mcrx_subscription = sub;
+
+    err = mcrx_subscription_join(sub);
+    if (err != 0) {
+        mcrx_subscription_unref(sub);
+        free(subinfo);
+        return -1;
+    }
+
+    return 0;
+}
+
+/* Unref mcrx context object (and more, if necessary) */
+int picoquic_mcrx_cleanup(struct mcrx_ctx* ctx) {
+    if (ctx == NULL) {
+        return -1;
+    }
+    mcrx_ctx_unref(ctx);
+    return 0;
+}
+
+/* Leave channel via mcrx */
+int picoquic_mcrx_leave(struct mcrx_subscription* sub) {
+    picoquic_mcrx_sub_info* info = (picoquic_mcrx_sub_info*)mcrx_subscription_get_userdata(sub);
+    mcrx_subscription_set_userdata(sub, 0);
+
+    if (info) {
+        free(info);
+    }
+
+    int err = mcrx_subscription_leave(sub);
+    if (err != 0) {
+        return -1;
+    }
+
+    sub = mcrx_subscription_unref(sub);
+    return 0;
+}

--- a/picoquic/multicast.c
+++ b/picoquic/multicast.c
@@ -33,6 +33,17 @@
 #include <errno.h>
 #endif
 
+/* Additional user-data stored in mcrx subscription context */
+struct picoquic_mcrx_sub_info {
+  int nb_packets;
+  picoquic_mc_channel_in_cnx_t* ch_in_cnx;
+};
+
+/* Additional user-data stored in mcrx subscription context */
+struct picoquic_mcrx_ctx_info {
+  picoquic_quic_t* quic;
+};
+
 /* Call custom do_receive callback function OR mcrx_ctx_receive_packets to receive packets */
 // TODO MC: is this function actually needed? Probably only if mcrx_ctx_set_receive_socket_handlers method does not work
 int picoquic_mcrx_receive_packets(struct mcrx_ctx *ctx, 
@@ -62,15 +73,25 @@ int picoquic_mcrx_receive_packets(struct mcrx_ctx *ctx,
 
 /* Callback called by mcrx when socket was added */
 int picoquic_mcrx_added_socket_cb(struct mcrx_ctx* ctx,
-    intptr_t handle,
+    intptr_t sub,
     int fd,
     int (*do_receive)(intptr_t handle, int fd)) 
 {
-    // TODO MC: Add socket to picoquic_quic context, so that it is included in picoquic_packet_loop_select's select() statement
+    // Add socket to picoquic_quic context, so that it is included in picoquic_packet_loop_select's select() statement
+    struct picoquic_mcrx_ctx_info* info = (struct picoquic_mcrx_ctx_info*)mcrx_ctx_get_userdata(ctx);
+    picoquic_quic_t* quicctx = info->quic;
+
+    if (quicctx->nb_multicast_fds >= PICOQUIC_MAX_MC_SOCKETS) {
+        fprintf(stdout, "Error: Could not add multicast socket to quic ctx, number of possible multicast sockets exceeded (%i)\n", PICOQUIC_MAX_MC_SOCKETS);
+        return -1;
+    }
+
+    quicctx->multicast_fds[quicctx->nb_multicast_fds] = fd;
+    quicctx->nb_multicast_fds++;
 
     // do_receive call maybe not needed?
     // TODO MC: Figure out how to use the do_receive callback
-    do_receive(handle, fd);
+    do_receive(sub, fd);
     return MCRX_ERR_OK;
 }
 
@@ -79,13 +100,36 @@ int picoquic_mcrx_removed_socket_cb(
     struct mcrx_ctx* ctx,
     int fd)
 {
-    // TODO MC: Remove socket to picoquic_quic context, so that it is excluded from picoquic_packet_loop_select's select() statement
+    // Remove socket to picoquic_quic context, so that it is excluded from picoquic_packet_loop_select's select() statement
+    struct picoquic_mcrx_ctx_info* info = (struct picoquic_mcrx_ctx_info*)mcrx_ctx_get_userdata(ctx);
+    picoquic_quic_t* quicctx = info->quic;
+    int found = 0;
+
+    for (int i = 0; i < PICOQUIC_MAX_MC_SOCKETS; i++) {
+        if (quicctx->multicast_fds[i] == fd) {
+            found = 1;
+            quicctx->multicast_fds[i] = 0;
+            if (i < PICOQUIC_MAX_MC_SOCKETS - 1) {
+                for (int j = i; j < PICOQUIC_MAX_MC_SOCKETS - 1; j++) {
+                    quicctx->multicast_fds[j] = quicctx->multicast_fds[j + 1];
+                }
+            }
+        }
+    }
+
+    if (found) {
+        quicctx->nb_multicast_fds--;
+    } else {
+        fprintf(stdout, "Info: Socket to be removed from quic ctx not found in quic ctx\n");
+    }
+
+    fprintf(stdout, "Debug: mcrx_removed_socket_cb called\n");
 
     return MCRX_ERR_OK;
 }
 
 /* Initialize MCRX context and set receive socket handlers */
-int picoquic_mcrx_initialize(struct mcrx_ctx **ctxp) 
+int picoquic_mcrx_initialize(struct mcrx_ctx **ctxp, picoquic_quic_t* quicctx) 
 {
     if (*ctxp != NULL) {
         fprintf(stdout, "Error in picoquic_mcrx_initialize: ctx already created\n");
@@ -98,9 +142,16 @@ int picoquic_mcrx_initialize(struct mcrx_ctx **ctxp)
     }
 
     struct mcrx_ctx *ctx = *ctxp;
+    struct picoquic_mcrx_ctx_info* info = (struct picoquic_mcrx_ctx_info*)calloc(1, sizeof(struct picoquic_mcrx_ctx_info));
+    if (!info) {
+        ctx = mcrx_ctx_unref(ctx);
+        return -1;
+    }
 
+    info->quic = quicctx;
+
+    mcrx_ctx_set_userdata(ctx, (intptr_t)info);
     mcrx_ctx_set_log_priority(ctx, MCRX_LOGLEVEL_WARNING);
-    
     
     err = mcrx_ctx_set_receive_socket_handlers(ctx,
         picoquic_mcrx_added_socket_cb, picoquic_mcrx_removed_socket_cb);
@@ -119,11 +170,13 @@ int picoquic_mcrx_initialize(struct mcrx_ctx **ctxp)
 /* Callback called by mcrx to handle received packets */
 int picoquic_mcrx_receive_cb(struct mcrx_packet* pkt) {
     struct mcrx_subscription* sub = mcrx_packet_get_subscription(pkt);
-    picoquic_mcrx_sub_info* info = (picoquic_mcrx_sub_info*)mcrx_subscription_get_userdata(sub);
+    struct picoquic_mcrx_sub_info* info = (struct picoquic_mcrx_sub_info*)mcrx_subscription_get_userdata(sub);
 
     info->nb_packets++;
     uint8_t* data = 0;
     int len = mcrx_packet_get_contents(pkt, &data);
+
+    fprintf(stdout, "picoquic_mcrx_receive_cb called!\n");
 
     // TODO MC: Figure out how to use this callback (if it is actually called in our setup), maybe call something like `picoquic_incoming_packet_ex` here
 
@@ -176,7 +229,7 @@ int picoquic_mcrx_join(struct mcrx_ctx **ctxp, picoquic_mc_channel_in_cnx_t *ch_
         return -1;
     }
 
-    picoquic_mcrx_sub_info* subinfo = (picoquic_mcrx_sub_info*)calloc(sizeof(picoquic_mcrx_sub_info), 1);
+    struct picoquic_mcrx_sub_info* subinfo = (struct picoquic_mcrx_sub_info*)calloc(1, sizeof(struct picoquic_mcrx_sub_info));
     if (!subinfo) {
         mcrx_subscription_unref(sub);
         fprintf(stdout, "Error picoquic_mcrx_join: subinfo could not be alloced\n");
@@ -207,13 +260,18 @@ int picoquic_mcrx_cleanup(struct mcrx_ctx **ctxp) {
     if (ctx == NULL) {
         return -1;
     }
+    struct picoquic_mcrx_ctx_info* info = (struct picoquic_mcrx_ctx_info*)mcrx_ctx_get_userdata(ctx);
+    if (info) {
+        mcrx_ctx_set_userdata(ctx, 0);
+        free(info);
+    }
     mcrx_ctx_unref(ctx);
     return 0;
 }
 
 /* Leave channel via mcrx */
 int picoquic_mcrx_leave(struct mcrx_subscription* sub) {
-    picoquic_mcrx_sub_info* info = (picoquic_mcrx_sub_info*)mcrx_subscription_get_userdata(sub);
+    struct picoquic_mcrx_sub_info* info = (struct picoquic_mcrx_sub_info*)mcrx_subscription_get_userdata(sub);
     mcrx_subscription_set_userdata(sub, 0);
 
     if (info) {

--- a/picoquic/multicast.h
+++ b/picoquic/multicast.h
@@ -21,7 +21,7 @@
 
 #include <mcrx/libmcrx.h>
 
-int picoquic_mcrx_initialize(struct mcrx_ctx **ctxp, picoquic_quic_t* quicctx);
+int picoquic_mcrx_initialize(struct mcrx_ctx **ctxp, picoquic_multicast_channel_t* channel);
 int picoquic_mcrx_join(struct mcrx_ctx **ctxp, picoquic_mc_channel_in_cnx_t *ch_in_cnx);
 int picoquic_mcrx_receive_packets(struct mcrx_ctx **ctxp, int (*do_receive)(intptr_t handle, int fd), intptr_t* do_handle_val, int fd);
 int picoquic_mcrx_leave(struct mcrx_subscription* sub);

--- a/picoquic/multicast.h
+++ b/picoquic/multicast.h
@@ -21,8 +21,8 @@
 
 #include <mcrx/libmcrx.h>
 
-int picoquic_mcrx_initialize(struct mcrx_ctx *ctx);
-int picoquic_mcrx_join(struct mcrx_ctx *ctx, picoquic_mc_channel_in_cnx_t *ch_in_cnx);
-int picoquic_mcrx_receive_packets(struct mcrx_ctx *ctx, int (*do_receive)(intptr_t handle, int fd), intptr_t* do_handle_val, int fd);
+int picoquic_mcrx_initialize(struct mcrx_ctx **ctxp);
+int picoquic_mcrx_join(struct mcrx_ctx **ctxp, picoquic_mc_channel_in_cnx_t *ch_in_cnx);
+int picoquic_mcrx_receive_packets(struct mcrx_ctx **ctxp, int (*do_receive)(intptr_t handle, int fd), intptr_t* do_handle_val, int fd);
 int picoquic_mcrx_leave(struct mcrx_subscription* sub);
-int picoquic_mcrx_cleanup(struct mcrx_ctx* ctx);
+int picoquic_mcrx_cleanup(struct mcrx_ctx **ctxp);

--- a/picoquic/multicast.h
+++ b/picoquic/multicast.h
@@ -21,7 +21,7 @@
 
 #include <mcrx/libmcrx.h>
 
-int picoquic_mcrx_initialize(struct mcrx_ctx **ctxp);
+int picoquic_mcrx_initialize(struct mcrx_ctx **ctxp, picoquic_quic_t* quicctx);
 int picoquic_mcrx_join(struct mcrx_ctx **ctxp, picoquic_mc_channel_in_cnx_t *ch_in_cnx);
 int picoquic_mcrx_receive_packets(struct mcrx_ctx **ctxp, int (*do_receive)(intptr_t handle, int fd), intptr_t* do_handle_val, int fd);
 int picoquic_mcrx_leave(struct mcrx_subscription* sub);

--- a/picoquic/multicast.h
+++ b/picoquic/multicast.h
@@ -1,0 +1,28 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2017, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <mcrx/libmcrx.h>
+
+int picoquic_mcrx_initialize(struct mcrx_ctx *ctx);
+int picoquic_mcrx_join(struct mcrx_ctx *ctx, picoquic_mc_channel_in_cnx_t *ch_in_cnx);
+int picoquic_mcrx_receive_packets(struct mcrx_ctx *ctx, int (*do_receive)(intptr_t handle, int fd), intptr_t* do_handle_val, int fd);
+int picoquic_mcrx_leave(struct mcrx_subscription* sub);
+int picoquic_mcrx_cleanup(struct mcrx_ctx* ctx);

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -2343,10 +2343,6 @@ int picoquic_incoming_segment(
     picoquic_connection_id_t* previous_dest_id,
     picoquic_cnx_t** first_cnx)
 {
-    // TODO MC: Check if addr_to has most-significant bit pattern "1110" (224.0.0.0/4) -> multicast traffic
-    // For ipv6, it's the prefix ff00::/8 (MSBs: "11111111")
-    // In that case, we need special decryption with multicast keys, etc.
-
     int ret = 0;
     picoquic_cnx_t* cnx = NULL;
     picoquic_packet_header ph;
@@ -2357,6 +2353,28 @@ int picoquic_incoming_segment(
     int path_is_not_allocated = 0;
     uint8_t* bytes = NULL;
     picoquic_stream_data_node_t* decrypted_data = picoquic_stream_data_node_alloc(quic);
+    picoquic_multicast_channel_t* multicast_channel = NULL;
+
+    if (quic->nb_mc_channels > 0) {
+        uint16_t port = 0;
+        if (addr_to->sa_family == AF_INET) {
+            port = ((struct sockaddr_in*)addr_to)->sin_port;
+        } 
+        if (addr_to->sa_family == AF_INET6) {
+            port = ((struct sockaddr_in6*)addr_to)->sin6_port;
+        } 
+
+        for (int i = 0; i < quic->nb_mc_channels; i++) {
+            if (quic->mc_channels[i]->local_port == port) {
+                multicast_channel = quic->mc_channels[i];
+                fprintf(stdout, "DEBUG: Detected multicast data from channel: ");
+                print_hex_bytes(multicast_channel->channel_id.id, multicast_channel->channel_id.id_len);
+                fprintf(stdout, "\n");
+            }
+        }
+    }
+
+    // TODO MC: handle multicast data frames, so that they are not skipped
 
     if (decrypted_data == NULL) {
         return -1;

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -2600,6 +2600,7 @@ int picoquic_incoming_segment(
         if (cnx != NULL && cnx->cnx_state != picoquic_state_disconnected &&
             ph.ptype != picoquic_packet_version_negotiation) {
             cnx->nb_packets_received++;
+            // TODO MC: Make sure that this is reached in multicast setting, to avoid idle timeout
             cnx->latest_receive_time = current_time;
             /* Mark the sequence number as received */
             ret = picoquic_record_pn_received(cnx, ph.pc, ph.l_cid, ph.pn64, receive_time);

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -2343,6 +2343,10 @@ int picoquic_incoming_segment(
     picoquic_connection_id_t* previous_dest_id,
     picoquic_cnx_t** first_cnx)
 {
+    // TODO MC: Check if addr_to has most-significant bit pattern "1110" (224.0.0.0/4) -> multicast traffic
+    // For ipv6, it's the prefix ff00::/8 (MSBs: "11111111")
+    // In that case, we need special decryption with multicast keys, etc.
+
     int ret = 0;
     picoquic_cnx_t* cnx = NULL;
     picoquic_packet_header ph;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -704,8 +704,6 @@ typedef struct st_picoquic_mc_channel_in_cnx_t { // TODO MC: Maybe add pointer b
     uint64_t latest_limits_sequence_acked;
 } picoquic_mc_channel_in_cnx_t;
 
-#define PICOQUIC_MAX_MC_SOCKETS 2
-
 /* QUIC context, defining the tables of connections,
  * open sockets, etc.
  */

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -627,6 +627,10 @@ typedef struct st_picoquic_multicast_channel_t {
     uint64_t max_rate;
     uint64_t max_ack_delay;
     int is_retired;
+    int client_mode;     // 0: sending (server), 1: receiving (client)
+    int socket_open;     // bool, if a socket is opened
+    SOCKET_TYPE fd;      // fd of used local socket (client: via mcrx)
+    uint16_t local_port; // port of used local socket (server: sending, client: receiving - via mcrx)
 } picoquic_multicast_channel_t;
 
 // State of a multicast channel in a cnx (with buffers for extensions):
@@ -681,9 +685,6 @@ typedef struct st_picoquic_mc_channel_in_cnx_t { // TODO MC: Maybe add pointer b
     uint64_t latest_state_sequence_available;
     uint64_t latest_limits_sequence_available;
     struct mcrx_subscription* mcrx_subscription;
-    
-    // TODO MC: Find solution for sequence numbers starting from 0, but default value for these fields is also 0
-    //          Things like "key_available", "key acked", "mc_limits_acked", "mc_state_acked" could be omitted then
 
     // the following is used on server only:
     int mc_announce_acked;
@@ -846,9 +847,6 @@ typedef struct st_picoquic_quic_t {
     /* Multicast */
     picoquic_multicast_channel_t ** mc_channels;
     int nb_mc_channels;
-    // TODO MC: Move the multicast fd infos to the picoquic_mc_channel struct and also add a field for the socket port (local receive/send port) there
-    SOCKET_TYPE multicast_fds[PICOQUIC_MAX_MC_SOCKETS]; 
-    int nb_multicast_fds;
 
 #ifdef BBRExperiment
     bbr_exp bbr_exp_flags;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -30,6 +30,7 @@
 #include "picosplay.h"
 #include "picoquic.h"
 #include "picoquic_utils.h"
+#include <mcrx/libmcrx.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -669,7 +670,7 @@ typedef enum {
     picoqic_mc_state_error = 99
 } picoquic_mc_state_enum;
 
-typedef struct st_picoquic_mc_channel_in_cnx_t {
+typedef struct st_picoquic_mc_channel_in_cnx_t { // TODO MC: Maybe add pointer back to cnx here for convenience?
     picoquic_multicast_channel_t* channel;
     picoquic_mc_state_enum state;
     int key_available;
@@ -678,6 +679,7 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     uint64_t latest_key_sequence_available;
     uint64_t latest_state_sequence_available;
     uint64_t latest_limits_sequence_available;
+    struct mcrx_subscription* mcrx_subscription;
     
     // TODO MC: Find solution for sequence numbers starting from 0, but default value for these fields is also 0
     //          Things like "key_available", "key acked", "mc_limits_acked", "mc_state_acked" could be omitted then
@@ -699,6 +701,12 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     uint64_t latest_state_sequence_acked;
     uint64_t latest_limits_sequence_acked;
 } picoquic_mc_channel_in_cnx_t;
+
+/* Additional user-data stored in mcrx subscription context */
+typedef struct st_picoquic_mcrx_sub_info {
+  int nb_packets;
+  picoquic_mc_channel_in_cnx_t* ch_in_cnx;
+} picoquic_mcrx_sub_info;
 
 /* QUIC context, defining the tables of connections,
  * open sockets, etc.

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -35,6 +35,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#include "picosocks.h"
 
 #ifndef PICOQUIC_MAX_PACKET_SIZE
 #define PICOQUIC_MAX_PACKET_SIZE 1536
@@ -702,11 +703,7 @@ typedef struct st_picoquic_mc_channel_in_cnx_t { // TODO MC: Maybe add pointer b
     uint64_t latest_limits_sequence_acked;
 } picoquic_mc_channel_in_cnx_t;
 
-/* Additional user-data stored in mcrx subscription context */
-typedef struct st_picoquic_mcrx_sub_info {
-  int nb_packets;
-  picoquic_mc_channel_in_cnx_t* ch_in_cnx;
-} picoquic_mcrx_sub_info;
+#define PICOQUIC_MAX_MC_SOCKETS 2
 
 /* QUIC context, defining the tables of connections,
  * open sockets, etc.
@@ -849,6 +846,9 @@ typedef struct st_picoquic_quic_t {
     /* Multicast */
     picoquic_multicast_channel_t ** mc_channels;
     int nb_mc_channels;
+    // TODO MC: Move the multicast fd infos to the picoquic_mc_channel struct and also add a field for the socket port (local receive/send port) there
+    SOCKET_TYPE multicast_fds[PICOQUIC_MAX_MC_SOCKETS]; 
+    int nb_multicast_fds;
 
 #ifdef BBRExperiment
     bbr_exp bbr_exp_flags;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -25,6 +25,7 @@
 #include "picoquic_utils.h"
 #include "picoquic_unified_log.h"
 #include "tls_api.h"
+#include "multicast.h"
 #include <stdlib.h>
 #include <string.h>
 #ifndef _WINDOWS
@@ -1031,13 +1032,17 @@ int picoquic_schedule_mc_announce_and_join(picoquic_cnx_t* cnx, picoquic_multica
 
 int picoquic_join_mc_channel(picoquic_cnx_t* cnx, picoquic_multicast_channel_id_t* ch_id) {
     picoquic_mc_channel_in_cnx_t* ch_in_cnx = picoquic_find_multicast_channel_in_cnx(ch_id, cnx);
-    if (ch_in_cnx == NULL || ch_in_cnx->state < picoquic_mc_state_join_pending || ch_in_cnx->state >= picoquic_mc_state_retire_pending) {
+    if (ch_in_cnx == NULL || ch_in_cnx->state < picoquic_mc_state_join_pending || ch_in_cnx->state >= picoquic_mc_state_join_confirmed) {
         return -1;
     }
 
     ch_in_cnx->state_frame_scheduled = picoquic_mc_state_frame_joined;
     ch_in_cnx->state_scheduled = picoquic_mc_state_join_attempted;
     ch_in_cnx->state_reason_scheduled = picoquic_mc_state_reason_requested_by_server;
+
+    struct mcrx_ctx* ctx = NULL;
+    int test = picoquic_mcrx_initialize(ctx);
+    fprintf(stdout, "TEST MCRX RES: %i\n", test);
 
     return 0;
 }

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1036,24 +1036,36 @@ int picoquic_join_mc_channel(picoquic_cnx_t* cnx, picoquic_multicast_channel_id_
         return -1;
     }
 
-    ch_in_cnx->state_frame_scheduled = picoquic_mc_state_frame_joined;
-    ch_in_cnx->state_scheduled = picoquic_mc_state_join_attempted;
-    ch_in_cnx->state_reason_scheduled = picoquic_mc_state_reason_requested_by_server;
+    int ret = 0;
 
     struct mcrx_ctx *ctx = NULL;
-    int err = picoquic_mcrx_initialize(&ctx);
+    int err = picoquic_mcrx_initialize(&ctx, cnx->quic);
     if (err != 0) {
-        fprintf(stdout, "Error while initializing mcrx_ctx: %i", err);
-        return -1;
+        fprintf(stdout, "Error while initializing mcrx_ctx: %i\n", err);
+        ret = -1;
     }
-
-    err = picoquic_mcrx_join(&ctx, ch_in_cnx);
-    if (err != 0) {
-        fprintf(stdout, "Error while joining with mcrx_ctx: %i", err);
-        return -1;
+    if (ret == 0) {
+        err = picoquic_mcrx_join(&ctx, ch_in_cnx);
+        if (err != 0) {
+            fprintf(stdout, "Error while joining with mcrx_ctx: %i\n", err);
+            ret = -1;
+        }
     }
+    
+    if (ret != 0) {
+        ch_in_cnx->state_frame_scheduled = picoquic_mc_state_frame_declined_join;
+        ch_in_cnx->state_scheduled = picoquic_mc_state_left;
+        ch_in_cnx->state_reason_scheduled = picoquic_mc_state_reason_limit_violation;
+        fprintf(stdout, "Multicast join failed\n");
 
-    fprintf(stdout, "Joined multicast channel via mcrx\n");
+    } else {
+        ch_in_cnx->state_frame_scheduled = picoquic_mc_state_frame_joined;
+        ch_in_cnx->state_scheduled = picoquic_mc_state_join_attempted;
+        ch_in_cnx->state_reason_scheduled = picoquic_mc_state_reason_requested_by_server;
+        fprintf(stdout, "Joined multicast channel via mcrx\n");
+    }
+    
+
     return 0;
 }
 

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1040,10 +1040,20 @@ int picoquic_join_mc_channel(picoquic_cnx_t* cnx, picoquic_multicast_channel_id_
     ch_in_cnx->state_scheduled = picoquic_mc_state_join_attempted;
     ch_in_cnx->state_reason_scheduled = picoquic_mc_state_reason_requested_by_server;
 
-    struct mcrx_ctx* ctx = NULL;
-    int test = picoquic_mcrx_initialize(ctx);
-    fprintf(stdout, "TEST MCRX RES: %i\n", test);
+    struct mcrx_ctx *ctx = NULL;
+    int err = picoquic_mcrx_initialize(&ctx);
+    if (err != 0) {
+        fprintf(stdout, "Error while initializing mcrx_ctx: %i", err);
+        return -1;
+    }
 
+    err = picoquic_mcrx_join(&ctx, ch_in_cnx);
+    if (err != 0) {
+        fprintf(stdout, "Error while joining with mcrx_ctx: %i", err);
+        return -1;
+    }
+
+    fprintf(stdout, "Joined multicast channel via mcrx\n");
     return 0;
 }
 

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1039,7 +1039,7 @@ int picoquic_join_mc_channel(picoquic_cnx_t* cnx, picoquic_multicast_channel_id_
     int ret = 0;
 
     struct mcrx_ctx *ctx = NULL;
-    int err = picoquic_mcrx_initialize(&ctx, cnx->quic);
+    int err = picoquic_mcrx_initialize(&ctx, ch_in_cnx->channel);
     if (err != 0) {
         fprintf(stdout, "Error while initializing mcrx_ctx: %i\n", err);
         ret = -1;

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -583,7 +583,8 @@ int picoquic_packet_loop_select(picoquic_socket_ctx_t* s_ctx,
     int64_t delta_t,
     int * is_wake_up_event,
     picoquic_network_thread_ctx_t * thread_ctx,
-    int * socket_rank)
+    int * socket_rank,
+    SOCKET_TYPE* multicast_sockets, int nb_multicast_sockets)
 {
     fd_set readfds;
     struct timeval tv;
@@ -602,6 +603,13 @@ int picoquic_packet_loop_select(picoquic_socket_ctx_t* s_ctx,
             sockmax = (int)s_ctx[i].fd;
         }
         FD_SET(s_ctx[i].fd, &readfds);
+    }
+
+    for (int i = 0; i < nb_multicast_sockets; i++) {
+        if (sockmax < (int)multicast_sockets[i]) {
+            sockmax = (int)multicast_sockets[i];
+        }
+        FD_SET(multicast_sockets[i], &readfds);
     }
 
     *is_wake_up_event = 0;
@@ -660,6 +668,9 @@ int picoquic_packet_loop_select(picoquic_socket_ctx_t* s_ctx,
                         break;
                     }
                     else {
+                        char dest_txt[128];
+                        picoquic_addr_text(addr_dest, dest_txt, 128);
+                        fprintf(stdout, "Received data on unicast port, dest: %s\n", dest_txt);
                         /* Document incoming port */
                         if (addr_dest->ss_family == AF_INET6) {
                             ((struct sockaddr_in6*)addr_dest)->sin6_port = s_ctx[i].n_port;
@@ -667,6 +678,34 @@ int picoquic_packet_loop_select(picoquic_socket_ctx_t* s_ctx,
                         else if (addr_dest->ss_family == AF_INET) {
                             ((struct sockaddr_in*)addr_dest)->sin_port = s_ctx[i].n_port;
                         }
+                        break;
+                    }
+                }
+            }
+            for (int i = 0; i < nb_multicast_sockets; i++) {
+                if (FD_ISSET(multicast_sockets[i], &readfds)) {
+                    *socket_rank = i;
+                    bytes_recv = picoquic_recvmsg(multicast_sockets[i], addr_from,
+                        addr_dest, dest_if, received_ecn,
+                        buffer, buffer_max);
+
+                    if (bytes_recv <= 0) {
+                        DBG_PRINTF("Could not receive packet on UDP socket[%d]= %d!\n",
+                            i, (int)multicast_sockets[i]);
+                        break;
+                    }
+                    else {
+                        char dest_txt[128];
+                        picoquic_addr_text(addr_dest, dest_txt, 128);
+                        fprintf(stdout, "Received data on multicast port, dest: %s\n", dest_txt);
+                        // TODO MC: Document port in addr_dest somewhere in the context - so that we know, it is a multicast port
+                        // /* Document incoming port */
+                        // if (addr_dest->ss_family == AF_INET6) {
+                        //     ((struct sockaddr_in6*)addr_dest)->sin6_port;
+                        // }
+                        // else if (addr_dest->ss_family == AF_INET) {
+                        //     ((struct sockaddr_in*)addr_dest)->sin_port = s_ctx[i].n_port;
+                        // }
                         break;
                     }
                 }
@@ -743,6 +782,9 @@ void* picoquic_packet_loop_v3(void* v_ctx)
     picoquic_packet_loop_options_t options = { 0 };
     packet_loop_system_call_duration_t sc_duration = { 0 };
 
+    SOCKET_TYPE watch_multicast_fds[PICOQUIC_MAX_MC_SOCKETS];
+    int nb_multicast_fds = 0;
+
     int is_wake_up_event;
 #ifdef _WINDOWS
     WSADATA wsaData = { 0 };
@@ -800,6 +842,7 @@ void* picoquic_packet_loop_v3(void* v_ctx)
     /* Wait for packets */
     /* TODO: add stopping condition, was && (!just_once || !connection_done) */
     /* Actually, no, rely on the callback return code for that? */
+    // TODO MC: Check closing condition for usage with multicast
     while (ret == 0 && !thread_ctx->thread_should_close) {
         int socket_rank = -1;
         int64_t delta_t = 0;
@@ -845,12 +888,18 @@ void* picoquic_packet_loop_v3(void* v_ctx)
         bytes_recv = picoquic_packet_loop_wait(s_ctx, nb_sockets_available,
             &addr_from, &addr_to, &if_index_to, &received_ecn, &received_buffer,
             delta_t, &is_wake_up_event, thread_ctx, &socket_rank);
-#else
+#else        
+        if (quic->nb_multicast_fds != nb_multicast_fds) {
+            memcpy(watch_multicast_fds, quic->multicast_fds, sizeof(quic->multicast_fds));
+            nb_multicast_fds = quic->nb_multicast_fds;
+            fprintf(stdout, "Number of multicast fds changed: %i (before: %i)\n", nb_multicast_fds, quic->nb_multicast_fds);
+        }
+
         bytes_recv = picoquic_packet_loop_select(s_ctx, nb_sockets_available,
             &addr_from,
             &addr_to, &if_index_to, &received_ecn,
             buffer, sizeof(buffer),
-            delta_t, &is_wake_up_event, thread_ctx, &socket_rank);
+            delta_t, &is_wake_up_event, thread_ctx, &socket_rank, watch_multicast_fds, nb_multicast_fds);
         received_buffer = buffer;
 #endif
         current_time = picoquic_current_time();
@@ -936,7 +985,7 @@ void* picoquic_packet_loop_v3(void* v_ctx)
             /* We limit the number of packets sent in a loop, no make sure that
             * the code will not spend a lot of time sending packets while
             * packets may be adding in the receive queue.
-             */
+            */
 
             while (ret == 0 && nb_packets_sent < PICOQUIC_PACKET_LOOP_SEND_MAX) {
                 struct sockaddr_storage peer_addr;

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -846,7 +846,6 @@ void* picoquic_packet_loop_v3(void* v_ctx)
     /* Wait for packets */
     /* TODO: add stopping condition, was && (!just_once || !connection_done) */
     /* Actually, no, rely on the callback return code for that? */
-    // TODO MC: Check closing condition for usage with multicast
     while (ret == 0 && !thread_ctx->thread_should_close) {
         int socket_rank = -1;
         int64_t delta_t = 0;
@@ -892,7 +891,7 @@ void* picoquic_packet_loop_v3(void* v_ctx)
         bytes_recv = picoquic_packet_loop_wait(s_ctx, nb_sockets_available,
             &addr_from, &addr_to, &if_index_to, &received_ecn, &received_buffer,
             delta_t, &is_wake_up_event, thread_ctx, &socket_rank);
-#else        
+#else
         bytes_recv = picoquic_packet_loop_select(s_ctx, nb_sockets_available,
             &addr_from,
             &addr_to, &if_index_to, &received_ecn,
@@ -983,7 +982,7 @@ void* picoquic_packet_loop_v3(void* v_ctx)
             /* We limit the number of packets sent in a loop, no make sure that
             * the code will not spend a lot of time sending packets while
             * packets may be adding in the receive queue.
-            */
+             */
 
             while (ret == 0 && nb_packets_sent < PICOQUIC_PACKET_LOOP_SEND_MAX) {
                 struct sockaddr_storage peer_addr;

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -584,7 +584,7 @@ int picoquic_packet_loop_select(picoquic_socket_ctx_t* s_ctx,
     int * is_wake_up_event,
     picoquic_network_thread_ctx_t * thread_ctx,
     int * socket_rank,
-    SOCKET_TYPE* multicast_sockets, int nb_multicast_sockets)
+    picoquic_multicast_channel_t** mc_channels, int nb_mc_channels)
 {
     fd_set readfds;
     struct timeval tv;
@@ -605,11 +605,19 @@ int picoquic_packet_loop_select(picoquic_socket_ctx_t* s_ctx,
         FD_SET(s_ctx[i].fd, &readfds);
     }
 
-    for (int i = 0; i < nb_multicast_sockets; i++) {
-        if (sockmax < (int)multicast_sockets[i]) {
-            sockmax = (int)multicast_sockets[i];
+    for (int i = 0; i < nb_mc_channels; i++) {
+        if (mc_channels[i]->client_mode == 0) {
+            continue;
         }
-        FD_SET(multicast_sockets[i], &readfds);
+
+        int socket_open = mc_channels[i]->socket_open;
+        SOCKET_TYPE fd = mc_channels[i]->fd;
+        if (socket_open > 0) {
+            if (sockmax < (int)fd) {
+                sockmax = (int)fd;
+            }
+            FD_SET(fd, &readfds);
+        }
     }
 
     *is_wake_up_event = 0;
@@ -669,8 +677,7 @@ int picoquic_packet_loop_select(picoquic_socket_ctx_t* s_ctx,
                     }
                     else {
                         char dest_txt[128];
-                        picoquic_addr_text(addr_dest, dest_txt, 128);
-                        fprintf(stdout, "Received data on unicast port, dest: %s\n", dest_txt);
+                        picoquic_addr_text((struct sockaddr*)addr_dest, dest_txt, 128);
                         /* Document incoming port */
                         if (addr_dest->ss_family == AF_INET6) {
                             ((struct sockaddr_in6*)addr_dest)->sin6_port = s_ctx[i].n_port;
@@ -682,30 +689,35 @@ int picoquic_packet_loop_select(picoquic_socket_ctx_t* s_ctx,
                     }
                 }
             }
-            for (int i = 0; i < nb_multicast_sockets; i++) {
-                if (FD_ISSET(multicast_sockets[i], &readfds)) {
+            for (int i = 0; i < nb_mc_channels; i++) {
+                if (mc_channels[i]->client_mode == 0 || mc_channels[i]->socket_open == 0) {
+                    continue;
+                }
+
+                SOCKET_TYPE fd = mc_channels[i]->fd;
+
+                if (FD_ISSET(fd, &readfds)) {
                     *socket_rank = i;
-                    bytes_recv = picoquic_recvmsg(multicast_sockets[i], addr_from,
+                    bytes_recv = picoquic_recvmsg(fd, addr_from,
                         addr_dest, dest_if, received_ecn,
                         buffer, buffer_max);
 
                     if (bytes_recv <= 0) {
                         DBG_PRINTF("Could not receive packet on UDP socket[%d]= %d!\n",
-                            i, (int)multicast_sockets[i]);
+                            i, (int)fd);
                         break;
                     }
                     else {
                         char dest_txt[128];
-                        picoquic_addr_text(addr_dest, dest_txt, 128);
+                        picoquic_addr_text((struct sockaddr*)addr_dest, dest_txt, 128);
                         fprintf(stdout, "Received data on multicast port, dest: %s\n", dest_txt);
-                        // TODO MC: Document port in addr_dest somewhere in the context - so that we know, it is a multicast port
-                        // /* Document incoming port */
-                        // if (addr_dest->ss_family == AF_INET6) {
-                        //     ((struct sockaddr_in6*)addr_dest)->sin6_port;
-                        // }
-                        // else if (addr_dest->ss_family == AF_INET) {
-                        //     ((struct sockaddr_in*)addr_dest)->sin_port = s_ctx[i].n_port;
-                        // }
+                        /* Document incoming port */
+                        if (addr_dest->ss_family == AF_INET6) {
+                            mc_channels[i]->local_port = ((struct sockaddr_in6*)addr_dest)->sin6_port;
+                        }
+                        else if (addr_dest->ss_family == AF_INET) {
+                            mc_channels[i]->local_port = ((struct sockaddr_in*)addr_dest)->sin_port;
+                        }
                         break;
                     }
                 }
@@ -781,9 +793,6 @@ void* picoquic_packet_loop_v3(void* v_ctx)
     unsigned int nb_loop_immediate = 0;
     picoquic_packet_loop_options_t options = { 0 };
     packet_loop_system_call_duration_t sc_duration = { 0 };
-
-    SOCKET_TYPE watch_multicast_fds[PICOQUIC_MAX_MC_SOCKETS];
-    int nb_multicast_fds = 0;
 
     int is_wake_up_event;
 #ifdef _WINDOWS
@@ -889,17 +898,11 @@ void* picoquic_packet_loop_v3(void* v_ctx)
             &addr_from, &addr_to, &if_index_to, &received_ecn, &received_buffer,
             delta_t, &is_wake_up_event, thread_ctx, &socket_rank);
 #else        
-        if (quic->nb_multicast_fds != nb_multicast_fds) {
-            memcpy(watch_multicast_fds, quic->multicast_fds, sizeof(quic->multicast_fds));
-            nb_multicast_fds = quic->nb_multicast_fds;
-            fprintf(stdout, "Number of multicast fds changed: %i (before: %i)\n", nb_multicast_fds, quic->nb_multicast_fds);
-        }
-
         bytes_recv = picoquic_packet_loop_select(s_ctx, nb_sockets_available,
             &addr_from,
             &addr_to, &if_index_to, &received_ecn,
             buffer, sizeof(buffer),
-            delta_t, &is_wake_up_event, thread_ctx, &socket_rank, watch_multicast_fds, nb_multicast_fds);
+            delta_t, &is_wake_up_event, thread_ctx, &socket_rank, quic->mc_channels, quic->nb_mc_channels);
         received_buffer = buffer;
 #endif
         current_time = picoquic_current_time();

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -676,8 +676,6 @@ int picoquic_packet_loop_select(picoquic_socket_ctx_t* s_ctx,
                         break;
                     }
                     else {
-                        char dest_txt[128];
-                        picoquic_addr_text((struct sockaddr*)addr_dest, dest_txt, 128);
                         /* Document incoming port */
                         if (addr_dest->ss_family == AF_INET6) {
                             ((struct sockaddr_in6*)addr_dest)->sin6_port = s_ctx[i].n_port;
@@ -708,9 +706,6 @@ int picoquic_packet_loop_select(picoquic_socket_ctx_t* s_ctx,
                         break;
                     }
                     else {
-                        char dest_txt[128];
-                        picoquic_addr_text((struct sockaddr*)addr_dest, dest_txt, 128);
-                        fprintf(stdout, "Received data on multicast port, dest: %s\n", dest_txt);
                         /* Document incoming port */
                         if (addr_dest->ss_family == AF_INET6) {
                             mc_channels[i]->local_port = ((struct sockaddr_in6*)addr_dest)->sin6_port;


### PR DESCRIPTION
- Include `libmcrx` library in build process
- Add adapter methods for `libmcrx` receive process for method `mcrx_ctx_set_receive_socket_handlers()`
- Add multicast socket created in `libmcrx` to list of watched sockets in picoquic's `select()` statement (socket loop)
- Detect received multicast packages in `picoquic_incoming_segment()`