### PR TITLE
Add rate limiting and change application data prefix/suffix

### DIFF
--- a/multicast_sample/multicast.c
+++ b/multicast_sample/multicast.c
@@ -46,23 +46,27 @@
 #include <picosocks.h>
 #include "picoquic_multicast.h"
 
-const uint8_t multicast_datagram_prefix[3] = {
+const uint8_t multicast_datagram_prefix[PICOQUIC_MULTICAST_DATAGRAM_PREFIX_SUFFIX_LENGTH] = {
     PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE1,
     PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE2,
-    PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE3
+    PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE3,
+    PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE4,
+    PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE5
 };
-const uint8_t multicast_datagram_suffix[3] = {
+const uint8_t multicast_datagram_suffix[PICOQUIC_MULTICAST_DATAGRAM_PREFIX_SUFFIX_LENGTH] = {
     PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE1,
     PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE2, 
-    PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE3
+    PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE3,
+    PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE4,
+    PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE5
 };
 
 static void usage(char const * multicast_name)
 {
     fprintf(stderr, "Usage:\n");
-    fprintf(stderr, "    %s client server_name port folder\n", multicast_name);
+    fprintf(stderr, "    %s client server_name port folder max_rate\n", multicast_name);
     fprintf(stderr, "or :\n");
-    fprintf(stderr, "    %s server port_server port_sender cert_file private_key_file served_file_name\n", multicast_name);
+    fprintf(stderr, "    %s server port_server port_sender cert_file private_key_file max_rate served_file_name\n", multicast_name);
     exit(1);
 }
 
@@ -85,23 +89,26 @@ int main(int argc, char** argv)
         usage(argv[0]);
     }
     else if (strcmp(argv[1], "client") == 0) {
-        if (argc < 5) {
+        if (argc < 6) {
             usage(argv[0]);
         }
         else {
             int server_port = get_port(argv[0], argv[3]);
-            exit_code = picoquic_multicast_client(argv[2], server_port, argv[4]);
+            int max_rate = atoi(argv[5]);
+            exit_code = picoquic_multicast_client(argv[2], server_port, argv[4], max_rate);
         }
     }
     else if (strcmp(argv[1], "server") == 0) {
-        if (argc != 7) {
+        if (argc != 8) {
             usage(argv[0]);
         }
         else {
             int server_port = get_port(argv[0], argv[2]);
             int sender_port = get_port(argv[0], argv[3]);
 
-            exit_code = picoquic_multicast_server(server_port, sender_port, argv[4], argv[5], argv[6]);
+            int max_rate = atoi(argv[6]);
+
+            exit_code = picoquic_multicast_server(server_port, sender_port, argv[4], argv[5], max_rate, argv[7]);
         }
     }
     else

--- a/multicast_sample/multicast_client.c
+++ b/multicast_sample/multicast_client.c
@@ -113,6 +113,7 @@ typedef struct st_multicast_client_ctx_t
     uint16_t second_path_unique_id;
     uint16_t local_port;
     uint16_t alt_port;
+    picoquic_tp_multicast_client_params_t* tp_params;
 
     FILE *F;
     size_t bytes_received;
@@ -226,31 +227,37 @@ static void multicast_client_free_context(multicast_client_ctx_t *client_ctx)
     if (client_ctx->F != NULL) {
         (void)picoquic_file_close(client_ctx->F);
     }
+    if (client_ctx->tp_params != NULL) {
+        free(client_ctx->tp_params);
+    }
 }
 
 /* Return 1 if bytes array has datagram prefix */
-int multicast_client_has_datagram_prefix(uint8_t* bytes) {
-    fprintf(stdout, "DEBUG: First three bytes: 0x%x, 0x%x, 0x%x\n", bytes[0], bytes[1], bytes[2]);
-    if (bytes[0] == multicast_datagram_prefix[0] && 
-    bytes[1] == multicast_datagram_prefix[1] &&
-    bytes[2] == multicast_datagram_prefix[2]) {
-        return 1;
+int multicast_client_has_datagram_prefix(uint8_t* bytes, int prefix_length) {
+    fprintf(stdout, "DEBUG: First five bytes: 0x%x, 0x%x, 0x%x, 0x%x, 0x%x\n", bytes[0], bytes[1], bytes[2], bytes[3], bytes[4]);
+
+    for (int i = 0; i < prefix_length; i++) {
+        if (bytes[i] != multicast_datagram_prefix[i]) {
+            return 0;
+        }
     }
 
-    return 0;
+    return 1;
 }
 
 /* Return 1 if bytes array has datagram suffix */
-int multicast_client_has_datagram_suffix(uint8_t* bytes, size_t length) {
-    fprintf(stdout, "DEBUG: Last three bytes: 0x%x, 0x%x, 0x%x\n", bytes[length - 3], bytes[length - 2], bytes[length - 1]);
+int multicast_client_has_datagram_suffix(uint8_t* bytes, size_t length, int suffix_length) {
+    fprintf(stdout, "DEBUG: Last five bytes: 0x%x, 0x%x, 0x%x, 0x%x, 0x%x\n", bytes[length - 5], bytes[length - 4], bytes[length - 3], bytes[length - 2], bytes[length - 1]);
 
-    if (bytes[length - 3] == multicast_datagram_suffix[0] && 
-    bytes[length - 2] == multicast_datagram_suffix[1] &&
-    bytes[length - 2] == multicast_datagram_suffix[2]) {
-        return 1;
+    int bytepos = suffix_length;
+    for (int i = 0; i < suffix_length; i++) {
+        if (bytes[length - bytepos] != multicast_datagram_suffix[i]) {
+            return 0;
+        }
+        bytepos--;
     }
 
-    return 0;
+    return 1;
 }
 
 int multicast_client_callback_multicast(picoquic_multicast_channel_t* channel, 
@@ -279,20 +286,21 @@ int multicast_client_callback_multicast(picoquic_multicast_channel_t* channel,
                 int skip_bytes_start = 0;
                 int skip_bytes_end = 0;
                 int is_final_datagram = 0; // close file and mark as finished when file suffix detected
+                int prefix_suffix_length = PICOQUIC_MULTICAST_DATAGRAM_PREFIX_SUFFIX_LENGTH;
 
-                if (multicast_client_has_datagram_suffix(bytes, length) == 1) {
-                    skip_bytes_end = 3;
+                if (multicast_client_has_datagram_suffix(bytes, length, prefix_suffix_length) == 1) {
+                    skip_bytes_end = prefix_suffix_length;
                     is_final_datagram = 1;
                 }
 
-                if (client_ctx->F == NULL && multicast_client_has_datagram_prefix(bytes) == 1)
+                if (client_ctx->F == NULL && multicast_client_has_datagram_prefix(bytes, prefix_suffix_length) == 1)
                 {
                     /* Open the file to receive the data. This is done at the last possible moment,
                     * to minimize the number of files open simultaneously.
                     * When formatting the file_path, verify that the directory name is zero-length,
                     * or terminated by a proper file separator.
                        */
-                    skip_bytes_start = 3;
+                    skip_bytes_start = prefix_suffix_length;
                     char file_path[1024];
                     size_t dir_len = strlen(client_ctx->default_dir);
                     size_t file_name_len = strlen(PICOQUIC_MULTICAST_CLIENT_DATA_FILENAME);
@@ -544,7 +552,7 @@ static int multicast_client_loop_cb(picoquic_quic_t *quic, picoquic_packet_loop_
  * - Find the server's address
  * - Initialize the client context and create a client connection.
  */
-static int multicast_client_init(char const *server_name, int server_port, char const *default_dir,
+static int multicast_client_init(char const *server_name, int server_port, char const *default_dir, int max_rate,
                                  char const *ticket_store_filename, char const *token_store_filename,
                                  struct sockaddr_storage *server_address, picoquic_quic_t **quic, picoquic_cnx_t **cnx, multicast_client_ctx_t *client_ctx)
 {
@@ -605,9 +613,12 @@ static int multicast_client_init(char const *server_name, int server_port, char 
             picoquic_set_log_level(*quic, 1);
             picoquic_enable_path_callbacks_default(*quic, 1);
 
-            // Always enable multicast
+            // Multicast settings
+            client_ctx->tp_params = malloc(sizeof(picoquic_tp_multicast_client_params_t));
+            client_ctx->tp_params->max_aggregate_rate = (uint64_t)max_rate;
+
             picoquic_set_default_multicast_option(*quic, 1);
-            picoquic_set_default_multicast_client_params(*quic, NULL);
+            picoquic_set_default_multicast_client_params(*quic, client_ctx->tp_params);
             printf("init: Accept multicast: %s.\n", ((*quic)->default_multicast_option) ? "Yes" : "No");
         }
     }
@@ -676,7 +687,7 @@ static int multicast_client_init(char const *server_name, int server_port, char 
  * - The loop breaks if the client connection is finished.
  */
 
-int picoquic_multicast_client(char const *server_name, int server_port, char const *default_dir)
+int picoquic_multicast_client(char const *server_name, int server_port, char const *default_dir, int max_rate)
 {
     int ret = 0;
     struct sockaddr_storage server_address;
@@ -687,7 +698,7 @@ int picoquic_multicast_client(char const *server_name, int server_port, char con
     char const *ticket_store_filename = PICOQUIC_MULTICAST_CLIENT_TICKET_STORE;
     char const *token_store_filename = PICOQUIC_MULTICAST_CLIENT_TOKEN_STORE;
 
-    ret = multicast_client_init(server_name, server_port, default_dir, 
+    ret = multicast_client_init(server_name, server_port, default_dir, max_rate,
                                 ticket_store_filename, token_store_filename,
                                 &server_address, &quic, &cnx, &client_ctx);
 

--- a/multicast_sample/multicast_sender.c
+++ b/multicast_sample/multicast_sender.c
@@ -275,8 +275,6 @@ int multicast_sender_callback(picoquic_multicast_channel_t* channel,
                 break;
             }
 
-            fprintf(stdout, "debug: send datagram from application\n");
-
             multicast_sender_datagram_ctx_t* datagram_ctx = sender_ctx->first_datagram;
             if (!datagram_ctx->is_file_open) {
                 ret = multicast_sender_open_file(sender_ctx, datagram_ctx);
@@ -286,9 +284,10 @@ int multicast_sender_callback(picoquic_multicast_channel_t* channel,
                 }
             }
 
-            // Use 3-byte prefix and 3-byte suffix to indicate start and end of file to receiver
+            // Use 5-byte prefix and 5-byte suffix to indicate start and end of file to receiver
             int has_prefix = 0;
             int has_suffix = 0;
+            int prefix_suffix_length = PICOQUIC_MULTICAST_DATAGRAM_PREFIX_SUFFIX_LENGTH;
 
             /* Implement the zero copy callback */
             size_t available = datagram_ctx->file_length - datagram_ctx->file_sent;
@@ -297,15 +296,15 @@ int multicast_sender_callback(picoquic_multicast_channel_t* channel,
 
             if (datagram_ctx->file_sent == 0) {
                 has_prefix = 1;
-                available += 3;
+                available += prefix_suffix_length;
             }
             
-            if (available + 3 > length) {
+            if (available + prefix_suffix_length > length) {
                 available = length;
                 more_data = 1;
             } else {
                 has_suffix = 1;
-                available += 3;
+                available += prefix_suffix_length;
             }
 
             buffer = picoquic_provide_datagram_buffer_ex(bytes, available, picoquic_datagram_active_any_path);
@@ -313,19 +312,19 @@ int multicast_sender_callback(picoquic_multicast_channel_t* channel,
                 uint8_t* start_fread = buffer;
 
                 if (has_prefix == 1) {
-                    memcpy(buffer, multicast_datagram_prefix, 3);
-                    start_fread += 3;
-                    available -= 3;
+                    memcpy(buffer, multicast_datagram_prefix, prefix_suffix_length);
+                    start_fread += prefix_suffix_length;
+                    available -= prefix_suffix_length;
                 } 
 
                 size_t bytes_to_be_read = available;
                 if (has_suffix == 1) {
-                    bytes_to_be_read -= 3;
+                    bytes_to_be_read -= prefix_suffix_length;
                 }
 
                 size_t nb_read = fread(start_fread, 1, bytes_to_be_read, datagram_ctx->F);
 
-                if ((nb_read != available && has_suffix == 0) || (nb_read + 3 != available && has_suffix == 1)) {
+                if ((nb_read != available && has_suffix == 0) || (nb_read + prefix_suffix_length != available && has_suffix == 1)) {
                     /* Error while reading the file */
                     ret = -1;           
                 }
@@ -334,8 +333,8 @@ int multicast_sender_callback(picoquic_multicast_channel_t* channel,
                 }
 
                 if (has_suffix == 1) {
-                    memcpy(start_fread + nb_read, multicast_datagram_suffix, 3);
-                    fprintf(stdout, "Last three bytes to be sent: 0x%x, 0x%x, 0x%x\n", buffer[available - 3], buffer[available - 2], buffer[available - 1]);
+                    memcpy(start_fread + nb_read, multicast_datagram_suffix, prefix_suffix_length);
+                    fprintf(stdout, "Last five bytes to be sent: 0x%x, 0x%x, 0x%x, 0x%x, 0x%x\n", buffer[available - 5], buffer[available - 4], buffer[available - 3], buffer[available - 2], buffer[available - 1]);
                 }
             }
             else {
@@ -516,6 +515,9 @@ int picoquic_multicast_sender_start(int server_port,
 
     /* Force 127.0.0.1 as src ip for multicast packets for local tests */
     param.force_localhost_src_ip = 1;
+
+    // CHECK MC: GSO deactivated currently due to issues with local interfaces, may be re-activated later?
+    param.do_not_use_gso = 1;
 
     /* Start the background thread. */
     *thread_ctx = picoquic_start_custom_network_thread_ex(quic, &param,

--- a/multicast_sample/multicast_server.c
+++ b/multicast_sample/multicast_server.c
@@ -460,7 +460,7 @@ int multicast_server_callback(picoquic_cnx_t *cnx,
  * - The loop breaks if the socket return an error.
  */
 
-int picoquic_multicast_server(int server_port, int sender_port, const char *server_cert, const char *server_key, const char *served_file)
+int picoquic_multicast_server(int server_port, int sender_port, const char *server_cert, const char *server_key, int max_rate, const char *served_file)
 {
     // TODO MC: Start background thread mc sender server in this method somewhere
 
@@ -512,7 +512,7 @@ int picoquic_multicast_server(int server_port, int sender_port, const char *serv
         struct sockaddr_storage group_ip;
         picoquic_store_text_addr(&group_ip, PICOQUIC_MULTICAST_GROUP_IP, PICOQUIC_MULTICAST_GROUP_PORT);
 
-        picoquic_create_multicast_channel(quic, &default_context.mc_channel, PICOQUIC_MULTICAST_MAX_CLIENTS, &group_ip, NULL);
+        picoquic_create_multicast_channel(quic, &default_context.mc_channel, PICOQUIC_MULTICAST_MAX_CLIENTS, &group_ip, NULL, max_rate);
     }
 
     /* Wait for packets using the wait loop provided in the library.

--- a/multicast_sample/picoquic_multicast.h
+++ b/multicast_sample/picoquic_multicast.h
@@ -47,17 +47,23 @@ extern "C"
 #define PICOQUIC_MULTICAST_FILE_READ_ERROR 0x104
 #define PICOQUIC_MULTICAST_FILE_CANCEL_ERROR 0x105
 
-#define PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE1 0x01
-#define PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE2 0x02
-#define PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE3 0x03
-extern const uint8_t multicast_datagram_prefix[3];
+#define PICOQUIC_MULTICAST_DATAGRAM_PREFIX_SUFFIX_LENGTH 5
 
-#define PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE1 0xFF
-#define PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE2 0xFF
-#define PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE3 0xFF
-extern const uint8_t multicast_datagram_suffix[3];
+#define PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE1 0x00
+#define PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE2 0x01
+#define PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE3 0x02
+#define PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE4 0x03
+#define PICOQUIC_MULTICAST_DATAGRAM_PREFIX_BYTE5 0x04
+extern const uint8_t multicast_datagram_prefix[PICOQUIC_MULTICAST_DATAGRAM_PREFIX_SUFFIX_LENGTH];
 
-#define PICOQUIC_MULTICAST_CLIENT_DATA_FILENAME "output.txt"
+#define PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE1 0x04
+#define PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE2 0x03
+#define PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE3 0x02
+#define PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE4 0x01
+#define PICOQUIC_MULTICAST_DATAGRAM_SUFFIX_BYTE5 0x00
+extern const uint8_t multicast_datagram_suffix[PICOQUIC_MULTICAST_DATAGRAM_PREFIX_SUFFIX_LENGTH];
+
+#define PICOQUIC_MULTICAST_CLIENT_DATA_FILENAME "output"
 #define PICOQUIC_MULTICAST_CLIENT_TICKET_STORE "multicast_ticket_store.bin"
 #define PICOQUIC_MULTICAST_CLIENT_TOKEN_STORE "multicast_token_store.bin"
 #define PICOQUIC_MULTICAST_CLIENT_QLOG_DIR "./log"
@@ -86,7 +92,7 @@ typedef struct st_multicast_sender_ctx_t {
     int is_disconnected;
 } multicast_sender_ctx_t;
 
-int picoquic_multicast_client(char const *server_name, int server_port, char const *default_dir);
+int picoquic_multicast_client(char const *server_name, int server_port, char const *default_dir, int max_rate);
 
 int picoquic_multicast_sender_start(int server_port, 
     const char* server_cert, const char* server_key,
@@ -96,7 +102,7 @@ int picoquic_multicast_sender_start(int server_port,
     
 void picoquic_multicast_sender_stop(picoquic_network_thread_ctx_t* thread_ctx, multicast_sender_ctx_t* sender_ctx);
 
-int picoquic_multicast_server(int server_port, int sender_port, const char *server_cert, const char *server_key, const char *served_file);
+int picoquic_multicast_server(int server_port, int sender_port, const char *server_cert, const char *server_key, int max_rate, const char *served_file);
 
 #ifdef __cplusplus
 }

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -2711,12 +2711,11 @@ int picoquic_incoming_segment(
     uint8_t* bytes = NULL;
     picoquic_stream_data_node_t* decrypted_data = picoquic_stream_data_node_alloc(quic);
     picoquic_mc_channel_in_cnx_t* mc_ch_in_cnx = NULL;
-    picoquic_multicast_channel_t* multicast_channel = NULL;
 
     if (decrypted_data == NULL) {
         return -1;
     }
-
+    
     if (quic->nb_mc_channels > 0) {
         uint16_t port = 0;
         if (addr_to->sa_family == AF_INET) {
@@ -2731,14 +2730,10 @@ int picoquic_incoming_segment(
                 && quic->mc_channels[i]->client_mode && quic->mc_channels[i]->nb_used_in_cnx == 1
             ) {
                 mc_ch_in_cnx = quic->mc_channels[i]->used_in_cnx[0];
-                multicast_channel = mc_ch_in_cnx->channel;
-                fprintf(stdout, "DEBUG: Detected multicast data to port %u, interface %i from channel: ", port, if_index_to);
-                print_hex_bytes(multicast_channel->channel_id.id, multicast_channel->channel_id.id_len);
-                fprintf(stdout, "\n");
             }
         }
     }
-    
+
     /* Parse the header and decrypt the segment */
     if (mc_ch_in_cnx == NULL) {
         ret = picoquic_parse_header_and_decrypt(quic, raw_bytes, length, packet_length, addr_from,

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -742,7 +742,7 @@ void picoquic_set_default_multicast_option(picoquic_quic_t* quic, int multicast_
 int picoquic_set_default_multicast_client_params(picoquic_quic_t* quic, picoquic_tp_multicast_client_params_t* params);
 
 /* Create a new multicast channel within the given QUIC context */
-int picoquic_create_multicast_channel(picoquic_quic_t* quic, picoquic_multicast_channel_t** mc_channel, int max_clients, struct sockaddr_storage* group_ipv4, struct sockaddr_storage* group_ipv6);
+int picoquic_create_multicast_channel(picoquic_quic_t* quic, picoquic_multicast_channel_t** mc_channel, int max_clients, struct sockaddr_storage* group_ipv4, struct sockaddr_storage* group_ipv6, uint64_t max_rate);
 
 /* Prepare MC_ANNOUNCE, MC_KEY and MC_JOIN frame and queue sending to client */
 int picoquic_schedule_mc_announce_and_join(picoquic_cnx_t* cnx, picoquic_multicast_channel_t* channel);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1299,7 +1299,7 @@ typedef struct st_picoquic_multicast_channel_t {
     int nb_aead_secrets;
     picoquic_crypto_context_t crypto_context; 
     uint16_t hash_algorithm;
-    uint64_t max_rate;
+    uint64_t max_rate; // max rate in mbps for this channel
     uint64_t max_ack_delay;
     int is_retired;
 

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -864,21 +864,22 @@ int picoquic_set_default_multicast_client_params(picoquic_quic_t* quic,
     picoquic_tp_multicast_client_params_t* params)
 {
     if (params == NULL) {
-        if ((params = malloc(sizeof(*params))) == NULL) {
-            fprintf(stderr, "init: Could not alloc multicast_client_params");
-            return -1;
-        }
+        return -1;
+    }
 
-        // CHECK MC: Review these default settings and make them configurable
-        params->ipv4_channels_allowed = 1;
-        params->ipv6_channels_allowed = 0;
-        params->max_aggregate_rate = (uint8_t) 20; // 20 kbits
-        params->max_channel_ids = (uint8_t) 2;
+    // CHECK MC: Review these default settings
+    params->ipv4_channels_allowed = params->ipv4_channels_allowed ? params->ipv4_channels_allowed : 1;
+    params->ipv6_channels_allowed = params->ipv6_channels_allowed ? params->ipv6_channels_allowed : 0;
+    params->max_aggregate_rate = params->max_aggregate_rate ? params->max_aggregate_rate : (uint64_t) 30720; // 30720 kibps = 30 mibps
+    params->max_channel_ids = params->max_channel_ids ? params->max_channel_ids : (uint64_t) 2;
 
+    if (!params->hash_algorithms_supported) {
         params->hash_algorithms_supported = (uint8_t) 2;
         params->hash_algorithms_list[0] = (uint16_t) PICOQUIC_SHA384;
         params->hash_algorithms_list[1] = (uint16_t) PICOQUIC_SHA256;
+    }
 
+    if (!params->encryption_algorithms_supported) {
         params->encryption_algorithms_supported = 2;
         params->encryption_algorithms_list[0] = (uint16_t) PICOQUIC_AES_256_GCM_SHA384;
         params->encryption_algorithms_list[1] = (uint16_t) PICOQUIC_AES_128_GCM_SHA256;
@@ -931,7 +932,7 @@ picoquic_multicast_channel_t* picoquic_find_multicast_channel_global(picoquic_mu
 }
 
 int picoquic_create_multicast_channel(picoquic_quic_t* quic, picoquic_multicast_channel_t** mc_channel, int max_clients, 
-    struct sockaddr_storage* group_ipv4, struct sockaddr_storage* group_ipv6) 
+    struct sockaddr_storage* group_ipv4, struct sockaddr_storage* group_ipv6, uint64_t max_rate) 
 {
     if (quic == NULL || max_clients <= 0 || (group_ipv4 == NULL && group_ipv6 == NULL)) {
         fprintf(stderr, "could not create multicast channel: invalid parameters\n");
@@ -976,7 +977,7 @@ int picoquic_create_multicast_channel(picoquic_quic_t* quic, picoquic_multicast_
     new_channel->header_protection_algorithm = PICOQUIC_AES_256_GCM_SHA384;
     new_channel->aead_algorithm = PICOQUIC_AES_256_GCM_SHA384;
     new_channel->hash_algorithm = PICOQUIC_SHA384;
-    new_channel->max_rate = 20;
+    new_channel->max_rate = max_rate;
     new_channel->max_ack_delay = PICOQUIC_ACK_DELAY_MAX;
     new_channel->quic = quic;
     new_channel->send_mtu = PICOQUIC_INITIAL_MTU_IPV4; // change when ipv6 is supported

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -829,128 +829,147 @@ void* picoquic_packet_loop_multicast_send(void* v_ctx)
         DBG_PRINTF("%s", "Thread cannot run");
     }
 
+    // Very simple rate limiting according to announced limit of channel
+    // ENHANCE MC: Enhance rate limiting 
+    struct timespec start_time, current_time;
+    timespec_get(&start_time, TIME_UTC);
+
+    size_t bytes_sent_per_second = 0;
+    int max_bytes_per_second = ((int)mc_channel->max_rate * 128); // max rate is in kibps, 1 kib = 128 byte
+
     /* Start of Packet Loop */
     while (ret == 0 && !thread_ctx->thread_should_close) {
-        // CHECK MC: Need wake up event?
-        // if (is_wake_up_event) {
-        //     ret = loop_callback(quic, picoquic_packet_loop_wake_up, loop_callback_ctx, NULL);
-        // }
-        // else {
-            size_t bytes_sent = 0;
-            size_t nb_packets_sent = 0;
+        size_t bytes_sent = 0;
+        size_t nb_packets_sent = 0;
 
-            /* Start of send loop */
-            // CHECK MC: Limit of nb_packets_sent in send loop still needed? Maybe for wakeup events
-            while (ret == 0 && nb_packets_sent < PICOQUIC_PACKET_LOOP_SEND_MAX) {
-                struct sockaddr_storage peer_addr;
-                struct sockaddr_storage local_addr = { 0 };
-                int sock_ret = 0;
-                int sock_err = 0;
+        /* Start of send loop */
+        while (ret == 0 && nb_packets_sent < PICOQUIC_PACKET_LOOP_SEND_MAX) {
+            struct sockaddr_storage peer_addr;
+            struct sockaddr_storage local_addr = { 0 };
+            int sock_ret = 0;
+            int sock_err = 0;
 
-                // TODO MC: picoquic_prepare_next_packet_multicast
+            int remaining_capacity = max_bytes_per_second - bytes_sent_per_second;
+            if (remaining_capacity > 0) {
                 ret = picoquic_prepare_next_packet_multicast(quic,
                     send_buffer, send_buffer_size, &send_length,
                     &peer_addr, &local_addr, mc_channel,
                     send_msg_ptr);
+            } else {
+                send_length = 0;
+            }
 
-                if (ret != 0 || send_length <= 0) { 
-                    break;
-                }
+            if (ret != 0 || send_length <= 0) { 
+                break;
+            }
 
-                /* If send_msg_size is defined, sendmsg may send more than one packet.
-                 * We compute that to update the number of packets sent in the loop.
-                 */
-                nb_packets_sent += (send_msg_size == 0) ? 1 :
-                    (send_length + send_msg_size - 1) / (send_msg_size);
-                if (send_length > param->send_length_max) {
-                    param->send_length_max = send_length;
-                }
-                
-                SOCKET_TYPE send_socket = s_ctx[0].fd;
-                bytes_sent += send_length;
+            /* If send_msg_size is defined, sendmsg may send more than one packet.
+                * We compute that to update the number of packets sent in the loop.
+                */
+            nb_packets_sent += (send_msg_size == 0) ? 1 :
+                (send_length + send_msg_size - 1) / (send_msg_size);
+            if (send_length > param->send_length_max) {
+                param->send_length_max = send_length;
+            }
+            
+            SOCKET_TYPE send_socket = s_ctx[0].fd;
+            bytes_sent += send_length;
+            bytes_sent_per_second += send_length;
 
-                // Force 127.0.0.1 as src ip for local tests
-                if (param->force_localhost_src_ip) {
-                    picoquic_store_text_addr(&local_addr, "127.0.0.1", 0);
-                }
+            // Force 127.0.0.1 as src ip for local tests
+            if (param->force_localhost_src_ip) {
+                picoquic_store_text_addr(&local_addr, "127.0.0.1", 0);
+            }
 
-                char text[256];
-                fprintf(stdout, "DEBUG: Send multicast packet to %s\n", picoquic_addr_text((struct sockaddr*)&peer_addr, text, sizeof(text)));
+            // WORKAROUND: For whatever reason, in picoquic the port in every sockaddr struct is usually stored in host byte order.
+            // To get multicast working, we have to convert the port of the group address to network byte order before calling picoquic_sendmsg()
+            if (peer_addr.ss_family == AF_INET) {
+                ((struct sockaddr_in*)&peer_addr)->sin_port = htons(((struct sockaddr_in*)&peer_addr)->sin_port);
+            } else if (peer_addr.ss_family == AF_INET6) {
+                ((struct sockaddr_in6*)&peer_addr)->sin6_port = htons(((struct sockaddr_in6*)&peer_addr)->sin6_port);
+            }
 
-                // WORKAROUND: For whatever reason, in picoquic the port in every sockaddr struct is usually stored in host byte order.
-                // To get multicast working, we have to convert the port of the group address to network byte order before calling picoquic_sendmsg()
-                if (peer_addr.ss_family == AF_INET) {
-                    ((struct sockaddr_in*)&peer_addr)->sin_port = htons(((struct sockaddr_in*)&peer_addr)->sin_port);
-                } else if (peer_addr.ss_family == AF_INET6) {
-                    ((struct sockaddr_in6*)&peer_addr)->sin6_port = htons(((struct sockaddr_in6*)&peer_addr)->sin6_port);
-                }
-
-                if (send_socket == INVALID_SOCKET) {
+            if (send_socket == INVALID_SOCKET) {
+                sock_ret = -1;
+                sock_err = -1;
+            }
+            else
+            {
+                if (param->simulate_eio && send_length > PICOQUIC_MAX_PACKET_SIZE) {
+                    /* Test hook, simulating a driver that does not support GSO */
                     sock_ret = -1;
-                    sock_err = -1;
+                    sock_err = EIO;
+                    param->simulate_eio = 0;
                 }
-                else
-                {
-                    if (param->simulate_eio && send_length > PICOQUIC_MAX_PACKET_SIZE) {
-                        /* Test hook, simulating a driver that does not support GSO */
-                        sock_ret = -1;
-                        sock_err = EIO;
-                        param->simulate_eio = 0;
-                    }
-                    else {
+                else {
+                    sock_ret = picoquic_sendmsg(send_socket,
+                        (struct sockaddr*)&peer_addr, (struct sockaddr*)&local_addr, 0,
+                        (const char*)send_buffer, (int)send_length, (int)send_msg_size, &sock_err);
+                }
+            }
+            if (sock_ret <= 0) {
+                /* TODO: add a test in which the socket fails. */
+                // CLEAN MC: Refactor logging without using stdout
+                fprintf(stdout, "Could not send message to AF_to=%d, AF_from=%d, ret=%d, err=%d\n",
+                    peer_addr.ss_family, local_addr.ss_family, sock_ret, sock_err);
+
+                if (sock_err == EIO) {
+                    /* TODO: this is an error encountered if the system supports GSO, but
+                        * the specific interface driver does not. Main example is Mininet.
+                        * Not sure that we can treat that correctly. Try to minimize the
+                        * amount of untested code? Rely on config flag? Rely on error
+                        * recovery? */
+                    size_t packet_index = 0;
+                    size_t packet_size = send_msg_size;
+
+                    while (packet_index < send_length) {
+                        if (packet_index + packet_size > send_length) {
+                            packet_size = send_length - packet_index;
+                        }
                         sock_ret = picoquic_sendmsg(send_socket,
                             (struct sockaddr*)&peer_addr, (struct sockaddr*)&local_addr, 0,
-                            (const char*)send_buffer, (int)send_length, (int)send_msg_size, &sock_err);
-                    }
-                }
-                if (sock_ret <= 0) {
-                    /* TODO: add a test in which the socket fails. */
-                    // CLEAN MC: Refactor logging without using stdout
-                    fprintf(stdout, "Could not send message to AF_to=%d, AF_from=%d, ret=%d, err=%d",
-                        peer_addr.ss_family, local_addr.ss_family, sock_ret, sock_err);
-
-                    if (sock_err == EIO) {
-                        /* TODO: this is an error encountered if the system supports GSO, but
-                            * the specific interface driver does not. Main example is Mininet.
-                            * Not sure that we can treat that correctly. Try to minimize the
-                            * amount of untested code? Rely on config flag? Rely on error
-                            * recovery? */
-                        size_t packet_index = 0;
-                        size_t packet_size = send_msg_size;
-
-                        while (packet_index < send_length) {
-                            if (packet_index + packet_size > send_length) {
-                                packet_size = send_length - packet_index;
-                            }
-                            sock_ret = picoquic_sendmsg(send_socket,
-                                (struct sockaddr*)&peer_addr, (struct sockaddr*)&local_addr, 0,
-                                (const char*)(send_buffer + packet_index), (int)packet_size, 0, &sock_err);
-                            if (sock_ret > 0) {
-                                packet_index += packet_size;
-                            }
-                            else {
-                                fprintf(stdout, "Retry with packet size=%zu fails at index %zu, ret=%d, err=%d.",
-                                    packet_size, packet_index, sock_ret, sock_err);
-                                break;
-                            }
-                        }
+                            (const char*)(send_buffer + packet_index), (int)packet_size, 0, &sock_err);
                         if (sock_ret > 0) {
-                            fprintf(stdout, "Retry of %zu bytes by chunks of %zu bytes succeeds.",
-                                send_length, send_msg_size);
+                            packet_index += packet_size;
                         }
-                        if (send_msg_ptr != NULL) {
-                            /* Make sure that we do not use GSO anymore in this run */
-                            send_msg_ptr = NULL;
-                            fprintf(stdout, "%s", "UDP GSO was disabled");
+                        else {
+                            fprintf(stdout, "Retry with packet size=%zu fails at index %zu, ret=%d, err=%d.\n",
+                                packet_size, packet_index, sock_ret, sock_err);
+                            break;
                         }
+                    }
+                    if (sock_ret > 0) {
+                        fprintf(stdout, "Retry of %zu bytes by chunks of %zu bytes succeeds.\n",
+                            send_length, send_msg_size);
+                    }
+                    if (send_msg_ptr != NULL) {
+                        /* Make sure that we do not use GSO anymore in this run */
+                        send_msg_ptr = NULL;
+                        fprintf(stdout, "%s", "UDP GSO was disabled\n");
                     }
                 }
             }
+        }
 
-            if (ret == 0 && loop_callback != NULL) {
+        if (ret == 0) {
+            if (loop_callback != NULL) {
                 ret = loop_callback(quic, picoquic_packet_loop_after_send, loop_callback_ctx, &bytes_sent);
             }
-        // }
+        }
+
+        // Rate limiting
+        timespec_get(&current_time, TIME_UTC);
+        double elapsed_seconds = (current_time.tv_sec - start_time.tv_sec) +
+                                (current_time.tv_nsec - start_time.tv_nsec) / 1e9;
+
+        if (elapsed_seconds >= 1.0) {
+            printf("Total sent: %ld bytes = %lf mib in 1 second\n", bytes_sent_per_second, ((double)bytes_sent_per_second / 131072));
+            bytes_sent_per_second = 0; 
+            timespec_get(&start_time, TIME_UTC);
+        }
+
+        struct timespec ts = {0, (long)(10000000)};
+        nanosleep(&ts, NULL);
     }
 
     thread_ctx->thread_is_ready = 0;


### PR DESCRIPTION
- Make max rate configurable for client and server
- Add very simple rate limiting in multicast send loop
- Deactivate GSO in application code temporarily
- Change and extend application data prefix/suffix to 5-byte to not match any byte pattern in example video file
- Remove some debug output