### PR TITLE
Multicast/`MC_ACK`

### DIFF
--- a/loglib/logconvert.c
+++ b/loglib/logconvert.c
@@ -145,6 +145,10 @@ const char * ftype2str(picoquic_frame_type_enum_t ftype)
         return "mc_integrity_no_length";
     case picoquic_frame_type_mc_integrity_l:
         return "mc_integrity_with_length";
+    case picoquic_frame_type_mc_ack:
+        return "mc_ack";
+    case picoquic_frame_type_mc_ack_ecn:
+        return "mc_ack_with_ecn";
     default:
         return "unknown";
     }

--- a/loglib/qlog.c
+++ b/loglib/qlog.c
@@ -1494,6 +1494,65 @@ void qlog_mc_integrity_frame(uint64_t ftype, FILE* f, bytestream* s)
     }
 }
 
+void qlog_mc_ack_frame(uint64_t ftype, FILE* f, bytestream* s)
+{
+    uint64_t channel_id_length = 0;
+    byteread_vint(s, &channel_id_length);
+    fprintf(f, ", \"channel_id_length\": %"PRIu64"", channel_id_length);
+
+    fprintf(f, ", \"channel_id\": \"");
+    for (uint64_t i = 0; i < channel_id_length; i++) {
+        uint8_t byte = 0;
+        byteread_int8(s, &byte);
+        if (i == 0) {
+            fprintf(f, "%02X", byte);
+        } else {
+            fprintf(f, " %02X", byte);
+        }
+    }
+    fprintf(f, "\"");
+
+    uint64_t largest = 0;
+    uint64_t ack_delay = 0;
+    uint64_t num = 0;
+    byteread_vint(s, &largest);
+    fprintf(f, ", \"largest_acknowledged\": %"PRIu64"", largest);
+    byteread_vint(s, &ack_delay);
+    fprintf(f, ", \"ack_delay\": %"PRIu64"", ack_delay);
+    byteread_vint(s, &num);
+    fprintf(f, ", \"acked_ranges\": [");
+    for (uint64_t i = 0; i <= num; i++) {
+        uint64_t skip = 0;
+        int64_t start_range;
+        int64_t end_range;
+
+        if (i != 0) {
+            byteread_vint(s, &skip);
+            skip++;
+
+            largest -= skip;
+            fprintf(f, ", ");
+        }
+        uint64_t range = 0;
+        byteread_vint(s, &range);
+
+        start_range = largest - range;
+        end_range = (int64_t)largest;
+        fprintf(f, "[%"PRId64", %"PRId64"]", start_range, end_range);
+
+        largest -= range + 1;
+    }
+    fprintf(f, "]");
+    if (ftype == picoquic_frame_type_mc_ack_ecn) {
+        char const* ecn_name[3] = { "ect0", "ect1", "ce" };
+        for (int ecnx = 0; ecnx < 3; ecnx++) {
+            uint64_t ecn_v = 0;
+            byteread_vint(s, &ecn_v);
+            fprintf(f, ", \"%s\": %"PRIu64, ecn_name[ecnx], ecn_v);
+        }
+    }
+}
+
 void qlog_observed_address_frame(uint64_t ftype, FILE* f, bytestream* s)
 {
     unsigned int port = 0;
@@ -1691,6 +1750,10 @@ int qlog_packet_frame(bytestream * s, void * ptr)
     case picoquic_frame_type_mc_integrity:
     case picoquic_frame_type_mc_integrity_l:
         qlog_mc_integrity_frame(ftype, f, s);
+        break;
+    case picoquic_frame_type_mc_ack:
+    case picoquic_frame_type_mc_ack_ecn:
+        qlog_mc_ack_frame(ftype, f, s);
         break;
     default:
         s->ptr = ptr_before_type;

--- a/multicast_sample/multicast_client.c
+++ b/multicast_sample/multicast_client.c
@@ -309,6 +309,7 @@ int multicast_client_callback_multicast(picoquic_multicast_channel_t* channel,
                     }
                 }
 
+                // TODO MC: The delivery of DATAGRAM frames is not in order. Add logic to store fragment to disk in order
                 if (ret == 0 && length > 0)
                 {
                     fprintf(stdout, "GOT multicast datagram (fragment number: %lu, is_first: %i, is_last: %i) in application\n", fragment_number, is_first, is_last);
@@ -326,7 +327,7 @@ int multicast_client_callback_multicast(picoquic_multicast_channel_t* channel,
                     }
                 }
                 
-                // TODO MC: Figure out how to find the end of input for a file
+                // TODO MC: Not just close when receiving the final datagram, other packets with lower fragment number could arrive afterwards (unordered delivery)
                 if (ret == 0 && is_final_datagram == 1)
                 {
                     fprintf(stdout, "TRANSMISSION COMPLETE, CLOSING FILE\n");

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -4418,6 +4418,8 @@ const uint8_t* picoquic_decode_connection_close_frame(picoquic_cnx_t* cnx, const
     else {
         picoquic_state_enum old_state = cnx->cnx_state;
         cnx->cnx_state = (cnx->cnx_state < picoquic_state_client_ready_start || cnx->crypto_context[picoquic_epoch_1rtt].aead_decrypt == NULL) ? picoquic_state_disconnected : picoquic_state_closing_received;
+        
+        // TODO MC: What happens with active multicast channels when the unicast cnx is closed by remote?
 
         if (cnx->callback_fn != NULL && cnx->cnx_state != old_state && cnx->cnx_state == picoquic_state_disconnected) {
             (void)(cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx, NULL);
@@ -8396,7 +8398,7 @@ uint8_t* picoquic_format_mc_ack_frame(picoquic_mc_channel_in_cnx_t* channel, uin
     }
 
     if (bytes > after_stamp){ // TODO MC: Fix this: currently, bytes == after_stamp, which should not be the case
-        fprintf(stdout, "MC_ACK formatted\n");
+        fprintf(stdout, "Send MC_ACK\n");
         
         if (is_opportunistic) {
             /* TODO: should non opportunistic sending also reset these flags? */
@@ -8417,139 +8419,42 @@ uint8_t* picoquic_format_mc_ack_frame(picoquic_mc_channel_in_cnx_t* channel, uin
     return bytes;
 }
 
-// const uint8_t* picoquic_decode_mc_ack_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
-//     const uint8_t* bytes_max, uint64_t current_time, int is_ecn, picoquic_packet_data_t* packet_data)
-// {
-//     // TODO MC: Adapt this for multicast
+static const uint8_t* picoquic_skip_mc_ack_frame(const uint8_t* bytes, const uint8_t* bytes_max, int is_ecn)
+{
+    uint64_t nb_blocks;
+    uint8_t ch_id_length = 0;
 
-//     uint64_t path_id = 0;
-//     uint64_t num_block;
-//     uint64_t largest;
-//     uint64_t ack_delay;
-//     size_t   consumed;
-//     uint64_t ecnx3[3] = { 0, 0, 0 };
-//     uint64_t ftype = ((is_ecn) ? picoquic_frame_type_mc_ack_ecn : picoquic_frame_type_mc_ack);
-//     uint64_t largest_in_path = 0;
-//     picoquic_path_t * ack_path = cnx->path[0];
+    if ((bytes = picoquic_frames_varint_skip(bytes, bytes_max)) == NULL ||
+        (bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &ch_id_length)) == NULL ||
+        (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, (uint64_t)ch_id_length)) == NULL) 
+    {
+        return NULL;
+    }
 
-//     picoquic_packet_context_t* pkt_ctx = &cnx->pkt_ctx[pc];
-//     // TODO MC: Decode channel number and find pkt_ctx
+    if ((bytes = picoquic_frames_varint_skip(bytes, bytes_max)) != NULL) {
+        if (bytes != NULL &&
+            (bytes = picoquic_frames_varint_skip(bytes, bytes_max)) != NULL &&
+            (bytes = picoquic_frames_varint_decode(bytes, bytes_max, &nb_blocks)) != NULL &&
+            (bytes = picoquic_frames_varint_skip(bytes, bytes_max)) != NULL)
+        {
+            while (nb_blocks-- != 0) {
+                if ((bytes = picoquic_frames_varint_skip(bytes, bytes_max)) == NULL ||
+                    (bytes = picoquic_frames_varint_skip(bytes, bytes_max)) == NULL)
+                {
+                    break;
+                }
+            }
+        }
+    }
+   
+    if (bytes != NULL && is_ecn) {
+        for (int i = 0; bytes != NULL && i < 3; i++) {
+            bytes = picoquic_frames_varint_skip(bytes, bytes_max);
+        }
+    }
 
-//     if (picoquic_parse_ack_header(bytes, bytes_max-bytes, &num_block, NULL,
-//         &largest, &ack_delay, &consumed,
-//         cnx->remote_parameters.ack_delay_exponent) != 0) {
-//         picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, ftype);
-//         return NULL;
-//     }
-
-//     if (largest >= pkt_ctx->send_sequence) {
-//         picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION, ftype);
-//         return NULL;
-//     }
-
-//     bytes += consumed;
-
-//     /* Attempt to update the RTT */
-//     uint64_t time_stamp = 0;
-//     int is_new_ack = 0;
-//     // TODO MC: Find acked packet for multicast
-//     picoquic_packet_t* top_packet = picoquic_find_acked_packet(cnx, pkt_ctx, largest, current_time, &is_new_ack);
-//     picoquic_packet_t* p_retransmitted_previous = pkt_ctx->retransmitted_newest;
-
-//     if (top_packet != NULL && is_new_ack) {
-//         largest_in_path = top_packet->sequence_number;
-//         ack_path = top_packet->send_path;
-
-//         if (pkt_ctx->latest_time_acknowledged < top_packet->send_time) {
-//             pkt_ctx->latest_time_acknowledged = top_packet->send_time;
-//         }
-//         cnx->latest_receive_time = current_time;
-//         if (packet_data != NULL) {
-//             packet_data->last_ack_delay = ack_delay;
-//         }
-//     }
-
-//     do {
-//         uint64_t range;
-//         uint64_t block_to_block;
-
-//         if ((bytes = picoquic_frames_varint_decode(bytes, bytes_max, &range)) == NULL) {
-//             DBG_PRINTF("Malformed ACK RANGE, %d blocks remain.\n", (int)num_block);
-//             picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, ftype);
-//             bytes = NULL;
-//             break;
-//         }
-
-//         range++;
-//         if (largest + 1 < range) {
-//             DBG_PRINTF("ack range error: largest=%" PRIx64 ", range=%" PRIx64, largest, range);
-//             picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, ftype);
-//             bytes = NULL;
-//             break;
-//         }
-
-//         if (picoquic_process_ack_range(cnx, picoquic_packet_context_application, pkt_ctx, largest, range, &top_packet, current_time, packet_data, channel) != 0) {
-//             bytes = NULL;
-//             break;
-//         }
-
-//         if (range > 0) {
-//             p_retransmitted_previous = picoquic_check_spurious_retransmission(cnx, picoquic_packet_context_application, pkt_ctx,
-//                 largest + 1 - range, largest, current_time, time_stamp, p_retransmitted_previous, packet_data);
-//         }
-
-//         if (num_block-- == 0)
-//             break;
-
-//         /* Skip the gap */
-//         if ((bytes = picoquic_frames_varint_decode(bytes, bytes_max, &block_to_block)) == NULL) {
-//             DBG_PRINTF("    Malformed ACK GAP, %d blocks remain.\n", (int)num_block);
-//             picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, ftype);
-//             bytes = NULL;
-//             break;
-//         }
-
-//         block_to_block += 1; /* add 1, since zero is ruled out by varint, see spec. */
-//         block_to_block += range;
-
-//         if (largest < block_to_block) {
-//             DBG_PRINTF("ack gap error: largest=%" PRIx64 ", range=%" PRIx64 ", gap=%" PRIu64,
-//                 largest, range, block_to_block - range);
-//             picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, ftype);
-//             bytes = NULL;
-//             break;
-//         }
-
-//         largest -= block_to_block;
-//     } while (bytes != NULL);
-
-//     picoquic_dequeue_old_retransmitted_packets(cnx, pkt_ctx);
-
-//     if (bytes != 0 && is_ecn) {
-//         for (int ecnx = 0; bytes != NULL && ecnx < 3; ecnx++) {
-//             bytes = picoquic_frames_varint_decode(bytes, bytes_max, &ecnx3[ecnx]);
-//         }
-//     }
-
-//     if (bytes != 0 && is_ecn) {
-//         if (ecnx3[0] > pkt_ctx->ecn_ect0_total_remote) {
-//             pkt_ctx->ecn_ect0_total_remote = ecnx3[0];
-//         }
-//         if (ecnx3[1] > pkt_ctx->ecn_ect1_total_remote) {
-//             pkt_ctx->ecn_ect1_total_remote = ecnx3[1];
-//         }
-//         if (ecnx3[2] > pkt_ctx->ecn_ce_total_remote) {
-//             picoquic_per_ack_state_t ack_state = { 0 };
-//             ack_state.lost_packet_number = largest_in_path;
-//             pkt_ctx->ecn_ce_total_remote = ecnx3[2];
-//             cnx->congestion_alg->alg_notify(cnx, ack_path,
-//                 picoquic_congestion_notification_ecn_ec,
-//                 &ack_state, current_time);
-//         }
-//     }
-
-//     return bytes;
-// }
+    return bytes;
+}
 
 /* BDP frames as defined in https://tools.ietf.org/html/draft-kuhn-quic-0rtt-bdp-09
 */
@@ -9242,7 +9147,8 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, picoquic_path_t * path_x, const 
                         case picoquic_frame_type_mc_ack:
                         case picoquic_frame_type_mc_ack_ecn:
                             fprintf(stdout, "DETECTED MC_ACK frame\n");
-                            // bytes = picoquic_decode_mc_ack_frame(cnx, bytes, bytes_max, current_time, frame_id64 == picoquic_frame_type_mc_ack_ecn, &packet_data);
+                            bytes = picoquic_skip_mc_ack_frame(bytes, bytes_max, frame_id64 == picoquic_frame_type_mc_ack_ecn);
+                            // ENHANCE MC: Decode MC_ACK frame properly and use info for retransmissions when STREAM or other frames are supported in multicast channels
                             break;
                         default:
                             fprintf(stdout, "DETECTED unknown frame: %lx\n", frame_id64);
@@ -9594,6 +9500,10 @@ int picoquic_skip_frame(const uint8_t* bytes, size_t bytes_maxsize, size_t* cons
                 case picoquic_frame_type_mc_integrity_l:
                     bytes = picoquic_skip_mc_integrity_frame(bytes, bytes_max, frame_id64);
                     *pure_ack = 0;
+                    break;
+                case picoquic_frame_type_mc_ack:
+                case picoquic_frame_type_mc_ack_ecn:
+                    bytes = picoquic_skip_mc_ack_frame(bytes, bytes_max, frame_id64 == picoquic_frame_type_mc_ack_ecn);
                     break;
                 default:
                     /* Not implemented yet! */

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -3875,7 +3875,7 @@ void picoquic_process_ack_of_frames(picoquic_cnx_t* cnx, picoquic_packet_t* p,
 static int picoquic_process_ack_range(
     picoquic_cnx_t* cnx, picoquic_packet_context_enum pc, picoquic_packet_context_t * pkt_ctx,
     uint64_t highest, uint64_t range, picoquic_packet_t** ppacket,
-    uint64_t current_time, picoquic_packet_data_t* packet_data)
+    uint64_t current_time, picoquic_packet_data_t* packet_data, picoquic_mc_channel_in_cnx_t* mc_channel)
 {
     picoquic_packet_t* p = *ppacket;
     int ret = 0;
@@ -3900,7 +3900,11 @@ static int picoquic_process_ack_range(
                     old_path->is_ack_lost = 0;
                     old_path->is_ack_expected = 0;
                     /* Track timer for the packet */
-                    if (p->sequence_number >= picoquic_get_ack_number(cnx, old_path, pc)) {
+                    uint64_t ack_number = mc_channel != NULL ? 
+                        pkt_ctx->highest_acknowledged : 
+                        picoquic_get_ack_number(cnx, old_path, pc);
+
+                    if (p->sequence_number >= ack_number) {
                         old_path->nb_retransmit = 0;
                     }
 
@@ -3920,9 +3924,9 @@ static int picoquic_process_ack_range(
                 picoquic_process_ack_of_frames(cnx, p, 0, current_time);
 
                 /* Keep track of reception of ACK of 1RTT data */
-                if (p->ptype == picoquic_packet_1rtt_protected &&
+                if (mc_channel == NULL && (p->ptype == picoquic_packet_1rtt_protected &&
                     (cnx->cnx_state == picoquic_state_client_ready_start ||
-                        cnx->cnx_state == picoquic_state_server_false_start)) {
+                        cnx->cnx_state == picoquic_state_server_false_start))) {
                     /* Transition to client ready state.
                      * The handshake is complete, all the handshake packets are implicitly acknowledged */
                     picoquic_ready_state_transition(cnx, current_time);
@@ -4028,7 +4032,7 @@ const uint8_t* picoquic_decode_ack_frame(picoquic_cnx_t* cnx, const uint8_t* byt
                     break;
                 }
 
-                if (picoquic_process_ack_range(cnx, pc, pkt_ctx, largest, range, &top_packet, current_time, packet_data) != 0) {
+                if (picoquic_process_ack_range(cnx, pc, pkt_ctx, largest, range, &top_packet, current_time, packet_data, NULL) != 0) {
                     bytes = NULL;
                     break;
                 }
@@ -8192,6 +8196,361 @@ int picoquic_check_mc_integrity_needs_repeat(picoquic_cnx_t* cnx, const uint8_t*
     return ret;
 }
 
+/*
+ * MC_ACK frame
+*/
+
+int picoquic_is_ack_needed_multicast(picoquic_cnx_t* cnx, uint64_t current_time, uint64_t* next_wake_time,
+    int is_opportunistic)
+{
+    // CHECK MC: The ACK frame for multicast uses the global ACK transport paramters from the unicast connection
+    // but has its own ack context (because it is a different packet number space) and is based not on a global nb_packets_received,
+    // but only the number of packets received via this specific multicast channel. 
+    // The coordination between unicast params and multicast specific logic is somehow interesting.
+
+    if (cnx->client_mode == 0 || cnx->is_multicast_enabled == 0 || cnx->nb_mc_channels == 0) {
+        return 0;
+    }
+
+    for (int i = 0; i < cnx->nb_mc_channels; i++) {
+        picoquic_mc_channel_in_cnx_t* channel = cnx->mc_channels[i];
+
+        picoquic_ack_context_t* ack_ctx = &channel->ack_ctx;
+        uint64_t ack_gap = channel->cnx->ack_gap_remote;
+
+        if (ack_ctx->act[is_opportunistic].ack_needed) {
+            if (ack_ctx->act[is_opportunistic].is_immediate_ack_required) {
+                return 1;
+            }
+
+            if (ack_ctx->act[is_opportunistic].ack_after_fin) {
+                ack_ctx->act[is_opportunistic].ack_after_fin = 0;
+                return 1;
+            }
+            
+            if (ack_ctx->act[is_opportunistic].out_of_order_received && !channel->cnx->ack_ignore_order_remote) {
+                return 1;
+            }
+
+            if (channel->nb_packets_received < 128) {
+                ack_gap = 2;
+            }
+
+            if (ack_ctx->act[is_opportunistic].highest_ack_sent + ack_gap <= picoquic_sack_list_last(&ack_ctx->sack_list) ||
+                ack_ctx->act[is_opportunistic].time_oldest_unack_packet_received + channel->cnx->ack_delay_remote <= current_time) {
+                return 1;
+            }
+
+            if (ack_ctx->act[is_opportunistic].time_oldest_unack_packet_received + channel->cnx->ack_delay_remote < *next_wake_time) {
+                *next_wake_time = ack_ctx->act[is_opportunistic].time_oldest_unack_packet_received + channel->cnx->ack_delay_remote;
+                SET_LAST_WAKE(channel->cnx->quic, PICOQUIC_FRAME);
+            }
+        }
+        else if (ack_ctx->act[is_opportunistic].highest_ack_sent + 8 <= picoquic_sack_list_last(&ack_ctx->sack_list) &&
+            ack_ctx->act[is_opportunistic].highest_ack_sent_time + channel->cnx->ack_delay_remote <= current_time) {
+            /* Force sending an ack-of-ack from time to time, as a low priority action */
+            if (picoquic_sack_list_last(&ack_ctx->sack_list) == UINT64_MAX) {
+                return 0;
+            }
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+void picoquic_set_ack_needed_multicast(picoquic_mc_channel_in_cnx_t* channel, uint64_t current_time,
+    int is_immediate_ack_required)
+{
+    picoquic_ack_context_t* ack_ctx = &channel->ack_ctx;
+
+    if (!ack_ctx->act[0].ack_needed) {
+        ack_ctx->act[0].is_immediate_ack_required |= is_immediate_ack_required;
+        ack_ctx->act[0].ack_needed = 1;
+        ack_ctx->act[0].time_oldest_unack_packet_received = current_time;
+        ack_ctx->act[1].ack_needed = 1;
+        ack_ctx->act[1].time_oldest_unack_packet_received = current_time;
+    }
+}
+
+uint8_t* picoquic_format_mc_ack_frame(picoquic_mc_channel_in_cnx_t* channel, uint8_t* bytes, uint8_t* bytes_max,
+    int* more_data, uint64_t current_time, int is_opportunistic)
+{
+    uint64_t num_block = 0;
+    uint64_t ack_delay = 0;
+    uint64_t ack_range = 0;
+    uint64_t ack_gap = 0;
+    uint64_t lowest_acknowledged = 0;
+    picoquic_ack_context_t* ack_ctx = &channel->ack_ctx;
+    int is_ecn = ack_ctx->sending_ecn_ack;
+    uint8_t* after_stamp = bytes;
+    uint64_t ack_type_byte = (is_ecn) ? picoquic_frame_type_mc_ack_ecn : picoquic_frame_type_mc_ack;
+
+    /* Check that there something to acknowledge */
+    if (!picoquic_sack_list_is_empty(&ack_ctx->sack_list)) {
+
+        uint8_t* num_block_byte = NULL;
+        picoquic_sack_item_t* last_sack = picoquic_sack_last_item(&ack_ctx->sack_list);
+
+        if (current_time > ack_ctx->time_stamp_largest_received) {
+            ack_delay = current_time - ack_ctx->time_stamp_largest_received;
+            ack_delay >>= channel->cnx->local_parameters.ack_delay_exponent;
+        }
+
+        // CHECK MC: Does not support TIMESTAMP frame with MC_ACK currently, as this is an expired draft spec
+
+        // Frame type
+        // Channel ID Length
+        if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, ack_type_byte)) == NULL ||
+            (bytes = picoquic_frames_uint8_encode(bytes, bytes_max, channel->channel->channel_id.id_len)) == NULL) {
+            *more_data = 1;
+            return after_stamp;
+        }
+
+        // Channel ID
+        uint8_t bytes_copied = picoquic_format_multicast_channel_id(bytes, bytes_max - bytes, &channel->channel->channel_id);
+        if (bytes_copied == 0) {
+            *more_data = 1;
+            return after_stamp;
+        } else {
+            bytes += bytes_copied;
+        }
+
+        // Largest Acknowledged
+        // ACK Delay
+        if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, picoquic_sack_item_range_end(last_sack))) != NULL &&
+            (bytes = picoquic_frames_varint_encode(bytes, bytes_max, ack_delay)) != NULL) {
+            /* Reserve one byte for the number of blocks */
+            num_block_byte = bytes++;
+            /* Encode the size of the first ack range */
+            ack_range = picoquic_sack_item_range_end(last_sack) - picoquic_sack_item_range_start(last_sack);
+            bytes = picoquic_frames_varint_encode(bytes, bytes_max, ack_range);
+        }
+        if (bytes == NULL || num_block_byte == NULL) {
+            bytes = after_stamp;
+            *more_data = 1;
+        }
+        else {
+            /* Implement adaptive tuning of lowest repeat range */
+            int nb_sent_max_acked = 0;
+            int nb_sent_max_skip = 0;
+            picoquic_sack_item_t* next_sack = picoquic_sack_previous_item(last_sack);
+
+            /* Update send count for the top range */
+            picoquic_sack_item_record_sent(&ack_ctx->sack_list, last_sack, is_opportunistic);
+
+            /* Find the parameters of range selection: max number of repeats, 
+             * highest range splits required.
+             */
+            picoquic_sack_select_ack_ranges(&ack_ctx->sack_list, last_sack, 32, 
+                is_opportunistic, &nb_sent_max_acked, &nb_sent_max_skip);
+
+            /* Set the lowest acknowledged */
+            lowest_acknowledged = picoquic_sack_item_range_start(last_sack);
+            while (num_block < 32 && next_sack != NULL) {
+                if (picoquic_sack_item_nb_times_sent(next_sack, is_opportunistic) <= nb_sent_max_acked) {
+                    if (picoquic_sack_item_nb_times_sent(next_sack, is_opportunistic) == nb_sent_max_acked &&
+                        nb_sent_max_skip > 0) {
+                        nb_sent_max_skip--;
+                    }
+                    else {
+                        uint8_t* bytes_start_range = bytes;
+                        ack_gap = lowest_acknowledged - picoquic_sack_item_range_end(next_sack) - 2; /* per spec */
+                        ack_range = picoquic_sack_item_range_end(next_sack) - picoquic_sack_item_range_start(next_sack);
+
+                        if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, ack_gap)) == NULL ||
+                            (bytes = picoquic_frames_varint_encode(bytes, bytes_max, ack_range)) == NULL) {
+                            bytes = bytes_start_range;
+                            *more_data = 1;
+                            break;
+                        }
+                        else {
+                            picoquic_sack_item_record_sent(&ack_ctx->sack_list, next_sack, is_opportunistic);
+                            lowest_acknowledged = picoquic_sack_item_range_start(next_sack);
+                            num_block++;
+                        }
+                    }
+                }
+                next_sack = picoquic_sack_previous_item(next_sack);
+            }
+            /* When numbers are lower than 64, varint encoding fits on one byte */
+            *num_block_byte = (uint8_t)num_block;
+
+            /* Remember the ACK value and time */
+            ack_ctx->act[is_opportunistic].highest_ack_sent = picoquic_sack_list_last(&ack_ctx->sack_list);
+            ack_ctx->act[is_opportunistic].highest_ack_sent_time = current_time;
+        }
+
+        if (bytes > after_stamp && is_ecn) {
+            /* Try to encode the ECN bytes */
+            uint8_t* bytes_ecn = bytes;
+            if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, ack_ctx->ecn_ect0_total_local)) == NULL ||
+                (bytes = picoquic_frames_varint_encode(bytes, bytes_max, ack_ctx->ecn_ect1_total_local)) == NULL ||
+                (bytes = picoquic_frames_varint_encode(bytes, bytes_max, ack_ctx->ecn_ce_total_local)) == NULL)
+            {
+                bytes = bytes_ecn;
+                *more_data = 1;
+                picoquic_frames_varint_encode(after_stamp, bytes_max, picoquic_frame_type_mc_ack);
+            }
+        }
+    }
+
+    if (bytes > after_stamp){ // TODO MC: Fix this: currently, bytes == after_stamp, which should not be the case
+        fprintf(stdout, "MC_ACK formatted\n");
+        
+        if (is_opportunistic) {
+            /* TODO: should non opportunistic sending also reset these flags? */
+            ack_ctx->act[1].ack_needed = 0;
+            ack_ctx->act[1].ack_after_fin = 0;
+            ack_ctx->act[1].out_of_order_received = 0;
+        }
+        else {
+            channel->cnx->is_immediate_ack_required = 0;
+            ack_ctx->act[0].ack_needed = 0;
+            ack_ctx->act[0].ack_after_fin = 0;
+            ack_ctx->act[0].out_of_order_received = 0;
+            ack_ctx->act[0].is_immediate_ack_required = 0;
+        }
+    }
+
+
+    return bytes;
+}
+
+// const uint8_t* picoquic_decode_mc_ack_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
+//     const uint8_t* bytes_max, uint64_t current_time, int is_ecn, picoquic_packet_data_t* packet_data)
+// {
+//     // TODO MC: Adapt this for multicast
+
+//     uint64_t path_id = 0;
+//     uint64_t num_block;
+//     uint64_t largest;
+//     uint64_t ack_delay;
+//     size_t   consumed;
+//     uint64_t ecnx3[3] = { 0, 0, 0 };
+//     uint64_t ftype = ((is_ecn) ? picoquic_frame_type_mc_ack_ecn : picoquic_frame_type_mc_ack);
+//     uint64_t largest_in_path = 0;
+//     picoquic_path_t * ack_path = cnx->path[0];
+
+//     picoquic_packet_context_t* pkt_ctx = &cnx->pkt_ctx[pc];
+//     // TODO MC: Decode channel number and find pkt_ctx
+
+//     if (picoquic_parse_ack_header(bytes, bytes_max-bytes, &num_block, NULL,
+//         &largest, &ack_delay, &consumed,
+//         cnx->remote_parameters.ack_delay_exponent) != 0) {
+//         picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, ftype);
+//         return NULL;
+//     }
+
+//     if (largest >= pkt_ctx->send_sequence) {
+//         picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION, ftype);
+//         return NULL;
+//     }
+
+//     bytes += consumed;
+
+//     /* Attempt to update the RTT */
+//     uint64_t time_stamp = 0;
+//     int is_new_ack = 0;
+//     // TODO MC: Find acked packet for multicast
+//     picoquic_packet_t* top_packet = picoquic_find_acked_packet(cnx, pkt_ctx, largest, current_time, &is_new_ack);
+//     picoquic_packet_t* p_retransmitted_previous = pkt_ctx->retransmitted_newest;
+
+//     if (top_packet != NULL && is_new_ack) {
+//         largest_in_path = top_packet->sequence_number;
+//         ack_path = top_packet->send_path;
+
+//         if (pkt_ctx->latest_time_acknowledged < top_packet->send_time) {
+//             pkt_ctx->latest_time_acknowledged = top_packet->send_time;
+//         }
+//         cnx->latest_receive_time = current_time;
+//         if (packet_data != NULL) {
+//             packet_data->last_ack_delay = ack_delay;
+//         }
+//     }
+
+//     do {
+//         uint64_t range;
+//         uint64_t block_to_block;
+
+//         if ((bytes = picoquic_frames_varint_decode(bytes, bytes_max, &range)) == NULL) {
+//             DBG_PRINTF("Malformed ACK RANGE, %d blocks remain.\n", (int)num_block);
+//             picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, ftype);
+//             bytes = NULL;
+//             break;
+//         }
+
+//         range++;
+//         if (largest + 1 < range) {
+//             DBG_PRINTF("ack range error: largest=%" PRIx64 ", range=%" PRIx64, largest, range);
+//             picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, ftype);
+//             bytes = NULL;
+//             break;
+//         }
+
+//         if (picoquic_process_ack_range(cnx, picoquic_packet_context_application, pkt_ctx, largest, range, &top_packet, current_time, packet_data, channel) != 0) {
+//             bytes = NULL;
+//             break;
+//         }
+
+//         if (range > 0) {
+//             p_retransmitted_previous = picoquic_check_spurious_retransmission(cnx, picoquic_packet_context_application, pkt_ctx,
+//                 largest + 1 - range, largest, current_time, time_stamp, p_retransmitted_previous, packet_data);
+//         }
+
+//         if (num_block-- == 0)
+//             break;
+
+//         /* Skip the gap */
+//         if ((bytes = picoquic_frames_varint_decode(bytes, bytes_max, &block_to_block)) == NULL) {
+//             DBG_PRINTF("    Malformed ACK GAP, %d blocks remain.\n", (int)num_block);
+//             picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, ftype);
+//             bytes = NULL;
+//             break;
+//         }
+
+//         block_to_block += 1; /* add 1, since zero is ruled out by varint, see spec. */
+//         block_to_block += range;
+
+//         if (largest < block_to_block) {
+//             DBG_PRINTF("ack gap error: largest=%" PRIx64 ", range=%" PRIx64 ", gap=%" PRIu64,
+//                 largest, range, block_to_block - range);
+//             picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, ftype);
+//             bytes = NULL;
+//             break;
+//         }
+
+//         largest -= block_to_block;
+//     } while (bytes != NULL);
+
+//     picoquic_dequeue_old_retransmitted_packets(cnx, pkt_ctx);
+
+//     if (bytes != 0 && is_ecn) {
+//         for (int ecnx = 0; bytes != NULL && ecnx < 3; ecnx++) {
+//             bytes = picoquic_frames_varint_decode(bytes, bytes_max, &ecnx3[ecnx]);
+//         }
+//     }
+
+//     if (bytes != 0 && is_ecn) {
+//         if (ecnx3[0] > pkt_ctx->ecn_ect0_total_remote) {
+//             pkt_ctx->ecn_ect0_total_remote = ecnx3[0];
+//         }
+//         if (ecnx3[1] > pkt_ctx->ecn_ect1_total_remote) {
+//             pkt_ctx->ecn_ect1_total_remote = ecnx3[1];
+//         }
+//         if (ecnx3[2] > pkt_ctx->ecn_ce_total_remote) {
+//             picoquic_per_ack_state_t ack_state = { 0 };
+//             ack_state.lost_packet_number = largest_in_path;
+//             pkt_ctx->ecn_ce_total_remote = ecnx3[2];
+//             cnx->congestion_alg->alg_notify(cnx, ack_path,
+//                 picoquic_congestion_notification_ecn_ec,
+//                 &ack_state, current_time);
+//         }
+//     }
+
+//     return bytes;
+// }
+
 /* BDP frames as defined in https://tools.ietf.org/html/draft-kuhn-quic-0rtt-bdp-09
 */
 
@@ -8510,8 +8869,7 @@ int picoquic_decode_frames_multicast(picoquic_mc_channel_in_cnx_t* ch_in_cnx, co
 
         if (ack_needed) {
             ch_in_cnx->latest_receive_time = current_time;
-            // TODO MC: Implement MC_ACK frame
-            // picoquic_set_ack_needed(cnx, current_time, pc, path_x, 0);
+            picoquic_set_ack_needed_multicast(ch_in_cnx, current_time, 0);
         }
     }
 
@@ -8879,8 +9237,15 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, picoquic_path_t * path_x, const 
                         case picoquic_frame_type_mc_integrity: 
                         case picoquic_frame_type_mc_integrity_l: 
                             bytes = picoquic_decode_mc_integrity_frame(cnx, bytes, bytes_max, frame_id64, current_time);
+                            ack_needed = 1;
+                            break;
+                        case picoquic_frame_type_mc_ack:
+                        case picoquic_frame_type_mc_ack_ecn:
+                            fprintf(stdout, "DETECTED MC_ACK frame\n");
+                            // bytes = picoquic_decode_mc_ack_frame(cnx, bytes, bytes_max, current_time, frame_id64 == picoquic_frame_type_mc_ack_ecn, &packet_data);
                             break;
                         default:
+                            fprintf(stdout, "DETECTED unknown frame: %lx\n", frame_id64);
                             /* Not implemented yet! */
                             picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, frame_id64);
                             bytes = NULL;

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -3660,6 +3660,11 @@ int picoquic_check_frame_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes,
                 case picoquic_frame_type_mc_integrity_l:
                     ret = picoquic_check_mc_integrity_needs_repeat(cnx, bytes, p_bytes_max, frame_id64, no_need_to_repeat);
                     break;
+                case picoquic_frame_type_mc_ack:
+                case picoquic_frame_type_mc_ack_ecn:
+                    // CHECK MC: Do MC_ACK frames ever need repeat? (currently not, because no retransmissions are needed with only DATAGRAM frames supported in multicast channels)
+                    *no_need_to_repeat = 1;
+                    break;
                 default:
                     *no_need_to_repeat = 0;
                     break;
@@ -3833,6 +3838,10 @@ void picoquic_process_ack_of_frames(picoquic_cnx_t* cnx, picoquic_packet_t* p,
             ret = picoquic_process_ack_of_mc_integrity_frame(cnx, &p->bytes[byte_index], p->length - byte_index, ftype, &frame_length);
             byte_index += frame_length;
             break;
+        case picoquic_frame_type_mc_ack:
+        case picoquic_frame_type_mc_ack_ecn:
+            // TODO MC: Is it necessary to support ACK of MC_ACK frames?
+            // For now, ignore/do not support, as no retransmissions of MC_ACK frames are happening
         default:
             if (PICOQUIC_IN_RANGE(ftype, picoquic_frame_type_stream_range_min, picoquic_frame_type_stream_range_max)) {
                 ret = picoquic_process_ack_of_stream_frame(cnx, &p->bytes[byte_index], p->length - byte_index, &frame_length);
@@ -4418,7 +4427,7 @@ const uint8_t* picoquic_decode_connection_close_frame(picoquic_cnx_t* cnx, const
     else {
         picoquic_state_enum old_state = cnx->cnx_state;
         cnx->cnx_state = (cnx->cnx_state < picoquic_state_client_ready_start || cnx->crypto_context[picoquic_epoch_1rtt].aead_decrypt == NULL) ? picoquic_state_disconnected : picoquic_state_closing_received;
-        
+
         // TODO MC: What happens with active multicast channels when the unicast cnx is closed by remote?
 
         if (cnx->callback_fn != NULL && cnx->cnx_state != old_state && cnx->cnx_state == picoquic_state_disconnected) {
@@ -8419,7 +8428,7 @@ uint8_t* picoquic_format_mc_ack_frame(picoquic_mc_channel_in_cnx_t* channel, uin
     return bytes;
 }
 
-static const uint8_t* picoquic_skip_mc_ack_frame(const uint8_t* bytes, const uint8_t* bytes_max, int is_ecn)
+const uint8_t* picoquic_skip_mc_ack_frame(const uint8_t* bytes, const uint8_t* bytes_max, int is_ecn)
 {
     uint64_t nb_blocks;
     uint8_t ch_id_length = 0;

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -8034,7 +8034,8 @@ const uint8_t* picoquic_skip_mc_integrity_frame(const uint8_t* bytes, const uint
 
     // picoquic_frame_type_mc_integrity indicates that frame is extended until packet bounds
     if (picoquic_frame_type_mc_integrity) {
-        return bytes_max;
+        bytes = bytes_max;
+        return bytes;
     }
 
     uint8_t ch_id_length = 0;

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -8434,8 +8434,7 @@ const uint8_t* picoquic_skip_mc_ack_frame(const uint8_t* bytes, const uint8_t* b
     uint64_t nb_blocks;
     uint8_t ch_id_length = 0;
 
-    if ((bytes = picoquic_frames_varint_skip(bytes, bytes_max)) == NULL ||
-        (bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &ch_id_length)) == NULL ||
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &ch_id_length)) == NULL ||
         (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, (uint64_t)ch_id_length)) == NULL) 
     {
         return NULL;

--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -367,6 +367,12 @@ char const* textlog_frame_names(uint64_t frame_type)
     case picoquic_frame_type_mc_integrity_l:
         frame_name = "mc_integrity_with_length";
         break;
+    case picoquic_frame_type_mc_ack:
+        frame_name = "mc_ack";
+        break;
+    case picoquic_frame_type_mc_ack_ecn:
+        frame_name = "mc_ack_with_ecn";
+        break;
     default:
         if (PICOQUIC_IN_RANGE(frame_type, picoquic_frame_type_stream_range_min, picoquic_frame_type_stream_range_max)) {
             frame_name = "stream";

--- a/picoquic/logwriter.c
+++ b/picoquic/logwriter.c
@@ -580,6 +580,16 @@ static const uint8_t* picoquic_log_mc_integrity_frame(FILE* f, const uint8_t* by
     return bytes;
 }
 
+static const uint8_t* picoquic_log_mc_ack_frame(FILE* f, const uint8_t* bytes, const uint8_t* bytes_max, uint64_t ftype)
+{
+    const uint8_t* bytes_begin = bytes;
+    bytes = picoquic_log_varint_skip(bytes, bytes_max);
+    bytes = picoquic_skip_mc_ack_frame(bytes, bytes_max, ftype == picoquic_frame_type_mc_ack_ecn);
+    picoquic_binlog_frame(f, bytes_begin, bytes);
+
+    return bytes;
+}
+
 void picoquic_binlog_frames(FILE * f, const uint8_t* bytes, size_t length)
 {
     const uint8_t* bytes_max = bytes + length;
@@ -716,6 +726,10 @@ void picoquic_binlog_frames(FILE * f, const uint8_t* bytes, size_t length)
         case picoquic_frame_type_mc_integrity:
         case picoquic_frame_type_mc_integrity_l:
             bytes = picoquic_log_mc_integrity_frame(f, bytes, bytes_max, ftype);
+            break;
+        case picoquic_frame_type_mc_ack:
+        case picoquic_frame_type_mc_ack_ecn:
+            bytes = picoquic_log_mc_ack_frame(f, bytes, bytes_max, ftype);
             break;
         default:
             bytes = picoquic_log_erroring_frame(f, bytes, bytes_max);

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -3041,7 +3041,7 @@ int picoquic_incoming_segment(
         } else if (mc_ch_in_cnx != NULL) {
             mc_ch_in_cnx->nb_packets_received++;
             mc_ch_in_cnx->latest_receive_time = current_time;
-            ret = picoquic_record_pn_received_multicast(mc_ch_in_cnx, ph.pn64, receive_time);
+            ret = picoquic_record_pn_received_multicast(mc_ch_in_cnx, phm.pn, receive_time);
         }
         if (cnx != NULL) {
             picoquic_reinsert_by_wake_time(cnx->quic, cnx, current_time);

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -3041,6 +3041,7 @@ int picoquic_incoming_segment(
         } else if (mc_ch_in_cnx != NULL) {
             mc_ch_in_cnx->nb_packets_received++;
             mc_ch_in_cnx->latest_receive_time = current_time;
+            ret = picoquic_record_pn_received_multicast(mc_ch_in_cnx, ph.pn64, receive_time);
         }
         if (cnx != NULL) {
             picoquic_reinsert_by_wake_time(cnx->quic, cnx, current_time);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -171,12 +171,14 @@ typedef enum {
     picoquic_frame_type_mc_announce_v6 = 0xff3e812,
     picoquic_frame_type_mc_key = 0xff3e801,
     picoquic_frame_type_mc_join = 0xff3e802,
-    picoquic_frame_type_mc_state_multicast = 0xff3e80b,
-    picoquic_frame_type_mc_state_application = 0xff3e80c,
+    picoquic_frame_type_mc_leave = 0xff3e803,
     picoquic_frame_type_mc_integrity = 0xff3e804,
     picoquic_frame_type_mc_integrity_l = 0xff3e805,
-    picoquic_frame_type_mc_leave = 0xff3e803,
+    picoquic_frame_type_mc_ack = 0xff3e806,
+    picoquic_frame_type_mc_ack_ecn = 0xff3e807,
     picoquic_frame_type_mc_retire = 0xff3e80a,
+    picoquic_frame_type_mc_state_multicast = 0xff3e80b,
+    picoquic_frame_type_mc_state_application = 0xff3e80c,
 } picoquic_frame_type_enum_t;
 
 /* PMTU discovery requirement status */
@@ -2321,6 +2323,11 @@ uint8_t* picoquic_format_mc_integrity_frame(uint8_t* bytes,
     uint8_t* bytes_max, picoquic_mc_channel_in_cnx_t* ch_in_cnx, int * more_data);
 const uint8_t* picoquic_skip_mc_integrity_frame(const uint8_t* bytes, 
     const uint8_t* bytes_max, uint64_t ftype);
+
+int picoquic_is_ack_needed_multicast(picoquic_cnx_t* cnx, uint64_t current_time, uint64_t* next_wake_time,
+    int is_opportunistic);
+uint8_t* picoquic_format_mc_ack_frame(picoquic_mc_channel_in_cnx_t* channel, uint8_t* bytes, uint8_t* bytes_max,
+    int* more_data, uint64_t current_time, int is_opportunistic);
 
 int picoquic_skip_frame(const uint8_t* bytes, size_t bytes_max, size_t* consumed, int* pure_ack);
 const uint8_t* picoquic_skip_path_abandon_frame(const uint8_t* bytes, const uint8_t* bytes_max);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -2325,6 +2325,8 @@ uint8_t* picoquic_format_mc_integrity_frame(uint8_t* bytes,
     uint8_t* bytes_max, picoquic_mc_channel_in_cnx_t* ch_in_cnx, int * more_data);
 const uint8_t* picoquic_skip_mc_integrity_frame(const uint8_t* bytes, 
     const uint8_t* bytes_max, uint64_t ftype);
+const uint8_t* picoquic_skip_mc_ack_frame(const uint8_t* bytes, 
+    const uint8_t* bytes_max, int is_ecn);
 
 int picoquic_is_ack_needed_multicast(picoquic_cnx_t* cnx, uint64_t current_time, uint64_t* next_wake_time,
     int is_opportunistic);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -2022,6 +2022,8 @@ int picoquic_is_pn_already_received(picoquic_cnx_t* cnx, picoquic_packet_context
     picoquic_local_cnxid_t * l_cid, uint64_t pn64);
 int picoquic_record_pn_received(picoquic_cnx_t* cnx, picoquic_packet_context_enum pc,
     picoquic_local_cnxid_t* l_cid, uint64_t pn64, uint64_t current_microsec);
+int picoquic_record_pn_received_multicast(picoquic_mc_channel_in_cnx_t* channel,
+    uint64_t pn64, uint64_t current_microsec);
 
 void picoquic_sack_select_ack_ranges(picoquic_sack_list_t* sack_list, picoquic_sack_item_t* first_sack,
     int max_ranges, int is_opportunistic, int* nb_sent_max, int* nb_sent_max_skip);

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -5001,6 +5001,7 @@ int picoquic_connection_error_ex(picoquic_cnx_t* cnx, uint64_t local_error, uint
         cnx->local_error = local_error;
         cnx->local_error_reason = local_reason;
         cnx->cnx_state = picoquic_state_disconnecting;
+        // TODO MC: Set multicast joined state also to "leaving" or similar
     } else if (cnx->cnx_state < picoquic_state_server_false_start) {
         if (cnx->cnx_state != picoquic_state_handshake_failure &&
             cnx->cnx_state != picoquic_state_handshake_failure_resend) {

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1084,6 +1084,7 @@ picoquic_mc_channel_in_cnx_t* picoquic_add_channel_to_cnx(picoquic_cnx_t* cnx, p
 
     new_channel_in_cnx->channel = channel;
     new_channel_in_cnx->cnx = cnx;
+    picoquic_sack_list_init(&new_channel_in_cnx->ack_ctx.sack_list);
     cnx->mc_channels[cnx->nb_mc_channels] = new_channel_in_cnx;
     cnx->nb_mc_channels++;
 

--- a/picoquic/sacks.c
+++ b/picoquic/sacks.c
@@ -314,6 +314,43 @@ int picoquic_record_pn_received(picoquic_cnx_t* cnx,
     return ret;
 }
 
+int picoquic_record_pn_received_multicast(picoquic_mc_channel_in_cnx_t* channel,
+    uint64_t pn64, uint64_t current_microsec)
+{
+    int ret = 0;
+    picoquic_ack_context_t* ack_ctx = &channel->ack_ctx;
+    picoquic_sack_list_t* sack_list = &ack_ctx->sack_list;
+
+    if (sack_list != NULL) {
+        if (picoquic_sack_list_is_empty(sack_list)) {
+            /* This is the first packet ever received.. */
+            ack_ctx->time_stamp_largest_received = current_microsec;
+        }
+        else {
+            uint64_t pn_last = picoquic_sack_list_last(sack_list);
+            if (pn64 > pn_last) {
+                if (pn64 > pn_last + 1) {
+                    ack_ctx->act[0].out_of_order_received = 1;
+                    ack_ctx->act[1].out_of_order_received = 1;
+                }
+                ack_ctx->time_stamp_largest_received = current_microsec;
+            }
+            else
+            {
+                if (ack_ctx->act[0].ack_needed && pn64 < ack_ctx->act[0].highest_ack_sent) {
+                    ack_ctx->act[0].out_of_order_received = 1;
+                }
+                if (ack_ctx->act[1].ack_needed && pn64 < ack_ctx->act[1].highest_ack_sent) {
+                    ack_ctx->act[1].out_of_order_received = 1;
+                }
+            }
+        }
+
+        ret = picoquic_update_sack_list(sack_list, pn64, pn64, current_microsec);
+    }
+    return ret;
+}
+
 /* Compute the parameters of the ACK transmission.
  * We assume that there is space for up to N ranges, in addition to
  * the topmost one. We want to select the "most urgent" ones.

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -3205,13 +3205,39 @@ uint8_t * picoquic_prepare_multicast_init_frames(picoquic_cnx_t* cnx, picoquic_p
     return bytes;
 }
 
+/*
+ * Prepare MC_ACK frames
+ */
+uint8_t * picoquic_prepare_multicast_ack_frames(picoquic_cnx_t* cnx,
+    uint8_t * bytes, uint8_t * bytes_max, 
+    int * more_data, uint64_t current_time, int is_opportunistic)
+{
+    if (cnx->client_mode == 0 || cnx->mc_channels == NULL || cnx->nb_mc_channels == 0) {
+        return bytes;
+    }
+
+    for (int i = 0; i < cnx->nb_mc_channels; i++) {
+        picoquic_mc_channel_in_cnx_t* ch = cnx->mc_channels[i];
+
+        if (ch->state < picoquic_mc_state_leave_pending) {
+            fprintf(stdout, "Prepare MC_ACK frame\n");
+            uint8_t *bytes_next = picoquic_format_mc_ack_frame(ch, bytes, bytes_max, more_data, current_time, is_opportunistic);
+            if (bytes_next > bytes) {
+                bytes = bytes_next;            
+            }
+        }
+    }
+
+    return bytes;
+}
+
 /* 
  * Prepare MC_STATE frames to be sent back to the server from the client, when needed. 
  */
 uint8_t * picoquic_prepare_multicast_state_frames(picoquic_cnx_t* cnx,
     uint8_t * bytes, uint8_t * bytes_max, 
     int * more_data, int* is_pure_ack,
-    uint64_t current_time, uint64_t * next_wake_time)
+    uint64_t current_time)
 {
     if (cnx->mc_channels == NULL || cnx->nb_mc_channels == 0) {
         return bytes;
@@ -4010,6 +4036,8 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
             bytes_next = picoquic_format_ack_frame(cnx, bytes + length, bytes_max, &more_data,
                 current_time, pc, !is_nominal_ack_path);
             length = bytes_next - bytes;
+
+            // TODO MC: Add MC_ACK frame here as well?
         }
         /* document the send time & overhead */
         is_pure_ack = 0;
@@ -4062,6 +4090,13 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
                     bytes_next = picoquic_format_ack_frame(cnx, bytes_next, bytes_max, &more_data,
                         current_time, pc, !is_nominal_ack_path);
                     ack_sent = (bytes_next > bytes_ack);
+                }
+
+                if (picoquic_is_ack_needed_multicast(cnx, current_time, next_wake_time, !is_nominal_ack_path)) {
+                    uint8_t* bytes_mc_ack = bytes_next;
+                    bytes_next = picoquic_prepare_multicast_ack_frames(cnx, bytes_next, bytes_max, &more_data,
+                        current_time, !is_nominal_ack_path);
+                    ack_sent = ack_sent || (bytes_next > bytes_mc_ack);
                 }
 
                 /* if necessary, prepare the MAX STREAM frames */
@@ -4170,7 +4205,7 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
                         /* CLIENT: Send MC_STATE frames to server if required. */
                         bytes_next = picoquic_prepare_multicast_state_frames(cnx,
                         bytes_next, bytes_max, &more_data, &is_pure_ack,
-                        current_time, next_wake_time);
+                        current_time);
                     }
 
                     if (length > header_length || pmtu_discovery_needed != picoquic_pmtu_discovery_required ||

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -3220,7 +3220,6 @@ uint8_t * picoquic_prepare_multicast_ack_frames(picoquic_cnx_t* cnx,
         picoquic_mc_channel_in_cnx_t* ch = cnx->mc_channels[i];
 
         if (ch->state < picoquic_mc_state_leave_pending) {
-            fprintf(stdout, "Prepare MC_ACK frame\n");
             uint8_t *bytes_next = picoquic_format_mc_ack_frame(ch, bytes, bytes_max, more_data, current_time, is_opportunistic);
             if (bytes_next > bytes) {
                 bytes = bytes_next;            


### PR DESCRIPTION
Add `MC_ACK` support:
- Record received multicast packet numbers on client in ack context
- Add support for sending `MC_ACK` frame on unicast connection for received multicast packet numbers
- Server detects incoming `MC_ACK` frame (no in-depth decoding yet)
- Add logging for MC_ACK frame

Small things added:
- Add todo comments to client app, mentioning that out-of-order-delivery handling is still missing
- Small fix in skip of MC_INTEGRITY frame

Still missing: 
  - Server needs to properly decode `MC_ACK` frames (currently no multicast retransmissions and therefore not implemented)
  - Server should maybe send `ACK` via unicast for received `MC_ACK` frames
  - Client needs to handle `ACK` for `MC_ACK`