### PR TITLE
Multicast/cleanup application code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,7 +403,7 @@ endif()
 
 if (BUILD_MULTICAST)
     find_library(LIBMCRX_LIBRARY NAMES libmcrx.a PATHS /usr/lib /usr/local/lib)
-    find_path(LIBMCRX_INCLUDE_DIR NAMES libmcrx.h PATHS /usr/include /usr/local/include)
+    find_path(LIBMCRX_INCLUDE_DIR NAMES libmcrx.h PATHS /usr/include /usr/include/mcrx /usr/local/include)
     add_executable(multicast
         multicast_sample/multicast.c
         multicast_sample/multicast_server.c

--- a/multicast_sample/multicast.c
+++ b/multicast_sample/multicast.c
@@ -51,7 +51,7 @@ static void usage(char const * multicast_name)
     fprintf(stderr, "Usage:\n");
     fprintf(stderr, "    %s client server_name port folder max_rate\n", multicast_name);
     fprintf(stderr, "or :\n");
-    fprintf(stderr, "    %s server port_server port_sender cert_file private_key_file max_rate served_file_name\n", multicast_name);
+    fprintf(stderr, "    %s server port_server port_sender cert_file private_key_file max_rate served_file_name [client_threshold]\n", multicast_name);
     exit(1);
 }
 
@@ -84,7 +84,7 @@ int main(int argc, char** argv)
         }
     }
     else if (strcmp(argv[1], "server") == 0) {
-        if (argc != 8) {
+        if (argc < 8) {
             usage(argv[0]);
         }
         else {
@@ -92,8 +92,12 @@ int main(int argc, char** argv)
             int sender_port = get_port(argv[0], argv[3]);
 
             int max_rate = atoi(argv[6]);
+            int client_threshold = 1;
+            if (argc >= 9) {
+                client_threshold = atoi(argv[8]);
+            }
 
-            exit_code = picoquic_multicast_server(server_port, sender_port, argv[4], argv[5], max_rate, argv[7]);
+            exit_code = picoquic_multicast_server(server_port, sender_port, argv[4], argv[5], max_rate, argv[7], client_threshold);
         }
     }
     else

--- a/multicast_sample/multicast_client.c
+++ b/multicast_sample/multicast_client.c
@@ -1,42 +1,18 @@
-/*
- * Author: Christian Huitema
- * Copyright (c) 2020, Private Octopus, Inc.
- * All rights reserved.
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
-/* The "multicast" project builds a simple file transfer program that can be
+/* The "multicast" project builds a simple multicast application that can be
  * instantiated in client or server mode. The "multicast_client" implements
  * the client components of the multicast application.
+ * 
+ * The multicast client currently only receives DATAGRAM frames, where each DATAGRAM frame 
+ * contains a small custom application header defining a "fragment number" (so that the 
+ * client can rearrange the DATAGRAM frames into the correct order again) and an indicator
+ * if this is the first or the last fragment of the sent file.
  *
- * Developing the client requires two main components:
- *  - the client "callback" that implements the client side of the
- *    application protocol, managing the client side application context
- *    for the connection.
- *  - the client loop, that reads messages on the socket, submits them
- *    to the Quic context, let the client prepare messages, and send
- *    them on the appropriate socket.
- *
- * The Multicast Client uses the "qlog" option to produce Quic Logs as defined
+ * The multicast server uses the "qlog" option to produce Quic Logs as defined
  * in https://datatracker.ietf.org/doc/draft-marx-qlog-event-definitions-quic-h3/.
  * This is an optional feature, which requires linking with the "loglib" library,
- * and using the picoquic_set_qlog() API defined in "autoqlog.h". When a connection
+ * and using the picoquic_set_qlog() API defined in "autoqlog.h". . When a connection
  * completes, the code saves the log as a file named after the Initial Connection
- * ID (in hexa), with the suffix ".client.qlog".
+ * ID (in hexa), with the suffix ".server.qlog".
  */
 
 #include <stdint.h>
@@ -52,67 +28,18 @@
 /* Client context and callback management:
  *
  * The client application context is created before the connection
- * is created. It contains the list of files that will be required
- * from the server.
- * On initial start, the client creates all the stream contexts
- * that will be needed for the requested files, and marks all
- * these contexts as active.
- * Each stream context includes:
- *  - description of the stream state:
- *      name sent or not, FILE open or not, stream reset or not,
- *      stream finished or not.
- *  - index of the file in the list.
- *  - number of file name bytes sent.
- *  - stream ID.
- *  - the FILE pointer for reading the data.
- * Server side stream context is created when the client starts the
- * stream. It is closed when the file transmission
- * is finished, or when the stream is abandoned.
- *
+ * is created.
+ * 
  * The server side callback is a large switch statement, with one entry
  * for each of the call back events.
  */
-
-// CLEAN MC: Remove unused stuff in this file
-
-// typedef struct st_multicast_client_stream_ctx_t
-// {
-//     struct st_multicast_client_stream_ctx_t *next_stream;
-//     size_t file_rank;
-//     uint64_t stream_id;
-//     size_t name_length;
-//     size_t name_sent_length;
-    
-    
-//     uint64_t remote_error;
-//     unsigned int is_name_sent : 1;
-//     unsigned int is_file_open : 1;
-//     unsigned int is_stream_reset : 1;
-    
-// } multicast_client_stream_ctx_t;
-
 typedef struct st_multicast_client_ctx_t
 {
     picoquic_cnx_t *cnx;
     char const *default_dir;
-    char const *saved_alpn;
-    char const **file_names;
-    // multicast_client_stream_ctx_t *first_stream;
-    // multicast_client_stream_ctx_t *last_stream;
     struct sockaddr_storage server_address;
     struct sockaddr_storage multicast_group_address;
-    int notified_ready;
-    int nb_files;
     int nb_files_received;
-    int nb_files_failed;
-    int is_disconnected;
-    int multipath_allowed;
-    int multipath_initiated;
-    int multipath_state;
-    int multipath_probe_done;
-    uint16_t second_path_unique_id;
-    uint16_t local_port;
-    uint16_t alt_port;
     picoquic_tp_multicast_client_params_t* tp_params;
 
     FILE *F;
@@ -120,108 +47,7 @@ typedef struct st_multicast_client_ctx_t
     unsigned int is_stream_finished : 1;
 } multicast_client_ctx_t;
 
-// static int multicast_client_create_stream(picoquic_cnx_t *cnx,
-//                                           multicast_client_ctx_t *client_ctx, int file_rank)
-// {
-//     int ret = 0;
-//     multicast_client_stream_ctx_t *stream_ctx = (multicast_client_stream_ctx_t *)
-//         malloc(sizeof(multicast_client_stream_ctx_t));
-
-//     if (stream_ctx == NULL)
-//     {
-//         fprintf(stdout, "crstr: Memory Error, cannot create stream for file number %d\n", (int)file_rank);
-//         ret = -1;
-//     }
-//     else
-//     {
-//         memset(stream_ctx, 0, sizeof(multicast_client_stream_ctx_t));
-//         if (client_ctx->first_stream == NULL)
-//         {
-//             client_ctx->first_stream = stream_ctx;
-//             client_ctx->last_stream = stream_ctx;
-//         }
-//         else
-//         {
-//             client_ctx->last_stream->next_stream = stream_ctx;
-//             client_ctx->last_stream = stream_ctx;
-//         }
-//         stream_ctx->file_rank = file_rank;
-//         stream_ctx->stream_id = picoquic_get_next_local_stream_id(client_ctx->cnx, 0);
-//         stream_ctx->name_length = strlen(client_ctx->file_names[file_rank]);
-
-//         /* Mark the stream as active. The callback will be asked to provide data when
-//          * the connection is ready. */
-//         ret = picoquic_mark_active_stream(cnx, stream_ctx->stream_id, 1, stream_ctx);
-//         if (ret != 0)
-//         {
-//             fprintf(stdout, "crstr: Error %d, cannot initialize stream for file number %d\n", ret, (int)file_rank);
-//         }
-//         else
-//         {
-//             picoquic_set_stream_path_affinity(cnx, stream_ctx->stream_id, client_ctx->second_path_unique_id);
-//             printf("crstr: Opened stream %d for file %s\n", 4 * file_rank, client_ctx->file_names[file_rank]);
-//         }
-//     }
-
-//     return ret;
-// }
-
-// static void multicast_client_report(multicast_client_ctx_t *client_ctx)
-// {
-//     multicast_client_stream_ctx_t *stream_ctx = client_ctx->first_stream;
-
-//     while (stream_ctx != NULL)
-//     {
-//         char const *status;
-//         if (stream_ctx->is_stream_finished)
-//         {
-//             status = "complete";
-//         }
-//         else if (stream_ctx->is_stream_reset)
-//         {
-//             status = "reset";
-//         }
-//         else
-//         {
-//             status = "unknown status";
-//         }
-//         printf("%s: %s, received %zu bytes", client_ctx->file_names[stream_ctx->file_rank], status, stream_ctx->bytes_received);
-//         if (stream_ctx->is_stream_reset && stream_ctx->remote_error != PICOQUIC_MULTICAST_NO_ERROR)
-//         {
-//             char const *error_text = "unknown error";
-//             switch (stream_ctx->remote_error)
-//             {
-//             case PICOQUIC_MULTICAST_INTERNAL_ERROR:
-//                 error_text = "internal error";
-//                 break;
-//             case PICOQUIC_MULTICAST_NAME_TOO_LONG_ERROR:
-//                 error_text = "internal error";
-//                 break;
-//             case PICOQUIC_MULTICAST_NO_SUCH_FILE_ERROR:
-//                 error_text = "no such file";
-//                 break;
-//             case PICOQUIC_MULTICAST_FILE_READ_ERROR:
-//                 error_text = "file read error";
-//                 break;
-//             case PICOQUIC_MULTICAST_FILE_CANCEL_ERROR:
-//                 error_text = "cancelled";
-//                 break;
-//             default:
-//                 break;
-//             }
-//             printf(", error 0x%" PRIx64 " -- %s", stream_ctx->remote_error, error_text);
-//         }
-//         printf("\n");
-//         stream_ctx = stream_ctx->next_stream;
-//     }
-
-//     for (int i = 0; i < client_ctx->cnx->nb_paths; i++)
-//     {
-//         printf("Path[%d], packets sent: %" PRIu64 "\n", i,
-//                client_ctx->cnx->path[i]->pkt_ctx.send_sequence);
-//     }
-// }
-
+/* Close file and free context */
 static void multicast_client_free_context(multicast_client_ctx_t *client_ctx)
 {
     if (client_ctx->F != NULL) {
@@ -232,6 +58,7 @@ static void multicast_client_free_context(multicast_client_ctx_t *client_ctx)
     }
 }
 
+/* Application callback */
 int multicast_client_callback_multicast(picoquic_multicast_channel_t* channel, 
     uint64_t stream_id, uint8_t *bytes, size_t length, 
     picoquic_call_back_event_t fin_or_event, void *callback_ctx, void *v_stream_ctx
@@ -327,7 +154,7 @@ int multicast_client_callback_multicast(picoquic_multicast_channel_t* channel,
                     }
                 }
                 
-                // TODO MC: Not just close when receiving the final datagram, other packets with lower fragment number could arrive afterwards (unordered delivery)
+                // TODO MC: Not just close file and connection when receiving the final datagram, other packets with lower fragment number could arrive afterwards (unordered delivery)
                 if (ret == 0 && is_final_datagram == 1)
                 {
                     fprintf(stdout, "TRANSMISSION COMPLETE, CLOSING FILE\n");
@@ -336,12 +163,7 @@ int multicast_client_callback_multicast(picoquic_multicast_channel_t* channel,
                     client_ctx->is_stream_finished = 1;
                     client_ctx->nb_files_received++;
 
-                    if ((client_ctx->nb_files_received + client_ctx->nb_files_failed) >= client_ctx->nb_files)
-                    {
-                        /* everything is done, close the connection */
-                        // TODO MC: Maybe already leave the channel here
-                        // ret = picoquic_close(cnx, 0);
-                    }
+                    // TODO MC: Maybe already leave the channel here (but wait for the missing frames though!)
                 }
                 break;
             default:
@@ -352,6 +174,7 @@ int multicast_client_callback_multicast(picoquic_multicast_channel_t* channel,
     return ret;
 }
 
+/* Packet Loop Callback */
 int multicast_client_callback(picoquic_cnx_t *cnx,
                               uint64_t stream_id, uint8_t *bytes, size_t length,
                               picoquic_call_back_event_t fin_or_event, void *callback_ctx, void *v_stream_ctx)
@@ -374,11 +197,11 @@ int multicast_client_callback(picoquic_cnx_t *cnx,
             break;
         case picoquic_callback_stream_data:
         case picoquic_callback_stream_fin:
+            /* STREAM data arrival, will not happen in the current scenario */
             break;
         case picoquic_callback_stop_sending: /* Should not happen, treated as reset */
             /* Mark stream as abandoned, close the file, etc. */
             picoquic_reset_stream(cnx, stream_id, 0);
-            /* Fall through */
         case picoquic_callback_stream_reset: /* Server reset stream #x */
             break;
         case picoquic_callback_stateless_reset:
@@ -386,12 +209,9 @@ int multicast_client_callback(picoquic_cnx_t *cnx,
             break;
         case picoquic_callback_close:
             fprintf(stdout, "app: Received request to close connection\n");
-            client_ctx->is_disconnected = 1;
             break;
         case picoquic_callback_application_close:
             fprintf(stdout, "app: Received request to close application.\n");
-            /* Mark the connection as completed */
-            client_ctx->is_disconnected = 1;
             /* Remove the application callback */
             picoquic_set_callback(cnx, NULL, NULL);
             break;
@@ -416,14 +236,14 @@ int multicast_client_callback(picoquic_cnx_t *cnx,
             /* This callback is never used. */
             break;
         case picoquic_callback_prepare_to_send:
+            /* Prepare to send STREAM data, will never happen on the client */
             break;
         case picoquic_callback_almost_ready:
             fprintf(stdout, "app: Connection to the server completed, almost ready.\n");
             break;
         case picoquic_callback_ready:
-            /* TODO: Check that the transport parameters are what the multicast expects */
+            /* TODO: Check that the transport parameters are what the application expects */
             fprintf(stdout, "app: Connection to the server confirmed.\n");
-
             break;
         case picoquic_callback_multicast_join_possible:
             fprintf(stdout, "App: Multicast join possible\n");
@@ -441,13 +261,12 @@ int multicast_client_callback(picoquic_cnx_t *cnx,
     return ret;
 }
 
-/* Multicast client,  loop call back management.
+/* Multicast client, loop call back management.
  * The function "picoquic_packet_loop" will call back the application when it is ready to
  * receive or send packets, after receiving a packet, and after sending a packet.
  * We implement here a minimal callback that instruct "picoquic_packet_loop" to exit
  * when the connection is complete.
  */
-
 static int multicast_client_loop_cb(picoquic_quic_t *quic, picoquic_packet_loop_cb_enum cb_mode,
                                     void *callback_ctx, void *callback_arg)
 {
@@ -463,55 +282,14 @@ static int multicast_client_loop_cb(picoquic_quic_t *quic, picoquic_packet_loop_
         switch (cb_mode)
         {
         case picoquic_packet_loop_ready:
-            picoquic_packet_loop_options_t *options = (picoquic_packet_loop_options_t *)callback_arg;
-            options->provide_alt_port = 1;
-            fprintf(stdout, "netloop: Waiting for packets.\n");
-            break;
         case picoquic_packet_loop_after_receive:
+        case picoquic_packet_loop_port_update:
+        case picoquic_packet_loop_alt_port:
             break;
         case picoquic_packet_loop_after_send:
-            if (picoquic_get_cnx_state(cb_ctx->cnx) == picoquic_state_disconnected)
-            {
+            if (picoquic_get_cnx_state(cb_ctx->cnx) == picoquic_state_disconnected) {
                 ret = PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
             }
-            else
-            {
-                if (picoquic_get_cnx_state(cb_ctx->cnx) == picoquic_state_client_almost_ready && cb_ctx->notified_ready == 0)
-                {
-                    // CHECK MC: Check if handshake check below is needed
-                    /* if almost ready, display results of negotiation */
-                    if (picoquic_tls_is_psk_handshake(cb_ctx->cnx))
-                    {
-                        fprintf(stdout, "netloop: The session was properly resumed!\n");
-                        picoquic_log_app_message(cb_ctx->cnx,
-                                                 "%s", "netloop: The session was properly resumed!");
-                    }
-
-                    // CHECK MC: Check if 0-RTT should be supported
-                    if (cb_ctx->cnx->zero_rtt_data_accepted)
-                    {
-                        fprintf(stdout, "netloop: Zero RTT data is accepted!\n");
-                        picoquic_log_app_message(cb_ctx->cnx,
-                                                 "%s", "netloop: Zero RTT data is accepted!");
-                    }
-
-                    if (cb_ctx->cnx->alpn != NULL)
-                    {
-                        fprintf(stdout, "netloop: Negotiated ALPN: %s\n", cb_ctx->cnx->alpn);
-                        picoquic_log_app_message(cb_ctx->cnx,
-                                                 "netloop: Negotiated ALPN: %s", cb_ctx->cnx->alpn);
-                        cb_ctx->saved_alpn = picoquic_string_duplicate(cb_ctx->cnx->alpn);
-                    }
-                    cb_ctx->notified_ready = 1;
-                }
-            }
-
-            break;
-        case picoquic_packet_loop_port_update:
-            break;
-        case picoquic_packet_loop_alt_port:
-            cb_ctx->alt_port = *((uint16_t *)callback_arg);
-            fprintf(stdout, "netloop: ALT PORT SET: %i\n", cb_ctx->alt_port);
             break;
         default:
             ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
@@ -540,44 +318,29 @@ static int multicast_client_init(char const *server_name, int server_port, char 
     *cnx = NULL;
 
     /* Get the server's address */
-    if (ret == 0)
-    {
+    if (ret == 0) {
         int is_name = 0;
 
         ret = picoquic_get_server_address(server_name, server_port, server_address, &is_name);
-        if (ret != 0)
-        {
+        if (ret != 0) {
             fprintf(stderr, "init: Cannot get the IP address for <%s> port <%d>", server_name, server_port);
-        }
-        else if (is_name)
-        {
+        } else if (is_name) {
             sni = server_name;
         }
     }
 
-    /* Create a QUIC context. It could be used for many connections, but in this multicast we
-     * will use it for just one connection.
-     * The multicast code exercises just a small subset of the QUIC context configuration options:
-     * - use files to store tickets and tokens in order to manage retry and 0-RTT
-     * - set the congestion control algorithm to BBR
-     * - enable logging of encryption keys for wireshark debugging.
-     * - instantiate a binary log option, and log all packets.
-     */
-    if (ret == 0)
-    {
+    /* Create a QUIC context. It could be used for many connections, but in this application we
+     * will use it for just one connection. */
+    if (ret == 0) {
         *quic = picoquic_create(1, NULL, NULL, NULL, PICOQUIC_MULTICAST_ALPN, NULL, NULL,
                                 NULL, NULL, NULL, current_time, NULL,
                                 ticket_store_filename, NULL, 0);
 
-        if (*quic == NULL)
-        {
+        if (*quic == NULL) {
             fprintf(stderr, "init: Could not create quic context\n");
             ret = -1;
-        }
-        else
-        {
-            if (picoquic_load_retry_tokens(*quic, token_store_filename) != 0)
-            {
+        } else {
+            if (picoquic_load_retry_tokens(*quic, token_store_filename) != 0) {
                 fprintf(stderr, "init: No token file present. Will create one as <%s>.\n", token_store_filename);
             }
 
@@ -598,13 +361,12 @@ static int multicast_client_init(char const *server_name, int server_port, char 
             printf("init: Accept multicast: %s.\n", ((*quic)->default_multicast_option) ? "Yes" : "No");
         }
     }
+
     /* Initialize the callback context and create the connection context.
      * We use minimal options on the client side, keeping the transport
      * parameter values set by default for picoquic. This could be fixed later.
      */
-
-    if (ret == 0)
-    {
+    if (ret == 0) {
         client_ctx->default_dir = default_dir;
 
         printf("init: Starting connection to %s, port %d\n", server_name, server_port);
@@ -613,30 +375,26 @@ static int multicast_client_init(char const *server_name, int server_port, char 
         *cnx = picoquic_create_cnx(*quic, picoquic_null_connection_id, picoquic_null_connection_id,
                                    (struct sockaddr *)server_address, current_time, 0, sni, PICOQUIC_MULTICAST_ALPN, 1);
 
-        if (*cnx == NULL)
-        {
+        if (*cnx == NULL) {
             fprintf(stderr, "init: Could not create connection context\n");
             ret = -1;
-        }
-        else
-        {
+        } else {
             /* Document connection in client's context */
             client_ctx->cnx = *cnx;
+
             /* Set the client callback context */
             picoquic_set_callback(*cnx, multicast_client_callback, client_ctx);
+
             /* Client connection parameters could be set here, before starting the connection. */
             ret = picoquic_start_client_cnx(*cnx);
-            if (ret < 0)
-            {
+
+            if (ret < 0) {
                 fprintf(stderr, "init: Could not activate connection\n");
-            }
-            else
-            {
+            } else {
                 /* Printing out the initial CID, which is used to identify log files */
                 picoquic_connection_id_t icid = picoquic_get_initial_cnxid(*cnx);
                 printf("init: Initial connection ID: ");
-                for (uint8_t i = 0; i < icid.id_len; i++)
-                {
+                for (uint8_t i = 0; i < icid.id_len; i++) {
                     printf("%02x", icid.id[i]);
                 }
                 printf("\n");
@@ -662,7 +420,6 @@ static int multicast_client_init(char const *server_name, int server_port, char 
  *       if there is, send it.
  * - The loop breaks if the client connection is finished.
  */
-
 int picoquic_multicast_client(char const *server_name, int server_port, char const *default_dir, int max_rate)
 {
     int ret = 0;
@@ -678,8 +435,7 @@ int picoquic_multicast_client(char const *server_name, int server_port, char con
                                 ticket_store_filename, token_store_filename,
                                 &server_address, &quic, &cnx, &client_ctx);
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         /* Initialize all the streams contexts from the list of streams passed on the API. */
         client_ctx.server_address = server_address;
     }
@@ -688,28 +444,16 @@ int picoquic_multicast_client(char const *server_name, int server_port, char con
     param.local_port = (uint16_t)picoquic_uniform_random(30000) + 20000;
     param.extra_socket_required = 1;
     param.prefer_extra_socket = 0;
-    client_ctx.local_port = param.local_port;
 
     /* Wait for packets */
     ret = picoquic_packet_loop_v2(quic, &param, multicast_client_loop_cb, &client_ctx);
 
-    if (ret == 0)
-    {
-        fprintf(stdout, "client: Enable multicast: %s.\n", (client_ctx.cnx->is_multicast_enabled) ? "Success" : "Refused");
-    }
-
-    /* Done. At this stage, we could print out statistics, etc. */
-    // multicast_client_report(&client_ctx);
-
     /* Save tickets and tokens, and free the QUIC context */
-    if (quic != NULL)
-    {
-        if (picoquic_save_session_tickets(quic, ticket_store_filename) != 0)
-        {
+    if (quic != NULL) {
+        if (picoquic_save_session_tickets(quic, ticket_store_filename) != 0) {
             fprintf(stderr, "client: Could not store the saved session tickets.\n");
         }
-        if (picoquic_save_retry_tokens(quic, token_store_filename) != 0)
-        {
+        if (picoquic_save_retry_tokens(quic, token_store_filename) != 0) {
             fprintf(stderr, "client: Could not save tokens to <%s>.\n", token_store_filename);
         }
         picoquic_free(quic);

--- a/multicast_sample/multicast_sender.c
+++ b/multicast_sample/multicast_sender.c
@@ -1,42 +1,33 @@
-/*
-* Author: Christian Huitema
-* Copyright (c) 2020, Private Octopus, Inc.
-* All rights reserved.
-*
-* Permission to use, copy, modify, and distribute this software for any
-* purpose with or without fee is hereby granted, provided that the above
-* copyright notice and this permission notice appear in all copies.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
-* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
-/* The "multicast" project builds a simple file transfer program that can be
- * instantiated in client or server mode. The "multicast_client" implements
- * the client components of the multicast application.
+/* The "multicast" project builds a simple multicast application that can be
+ * instantiated in client or server mode. The "multicast_server" and "multicast_sender" implements
+ * the server components of the multicast application.
  *
- * Developing the client requires two main components:
- *  - the client "callback" that implements the client side of the
- *    application protocol, managing the client side application context
- *    for the connection.
- *  - the client loop, that reads messages on the socket, submits them
- *    to the Quic context, let the client prepare messages, and send
- *    them on the appropriate socket.
+ * The server currently works using two components:
+ * 
+ *  - the multicast control server (multicast_server.c) records the multicast channel state
+ *    of the clients (joined/left) and handles the lifecycle of the multicast sender (start, stop).
+ *    It is started directly when "multicast server <params>" is executed, initializes picoquic,
+ *    sets the picoquic callbacks for client interaction and starts the packet loop.
  *
- * The Multicast Client uses the "qlog" option to produce Quic Logs as defined
+ *  - the multicast sender (multicast_sender.c) runs in a separate thread within the server application
+ *    and is started by the control server, once a specified threshold of clients is reached 
+ *    (clients_threshold CLI parameter). The sender runs with the same quic context as the control 
+ *    server and "stupidly" sends out data from a file specified by the control server via a special 
+ *    send-only packet loop. Once the sender is finished with sending the file, it calls a specified 
+ *    callback in the control server. The control server then invokes retiring of all clients for that 
+ *    multicast chanenl and stops the sender thread.
+ * 
+ * The multicast sender currently only sends out DATAGRAM frames contining the specified file,
+ * where each DATAGRAM frame contains a small custom application header defining a "fragment number"
+ * (so that the clients can rearrange the DATAGRAM frames into the correct order again) and an indicator
+ * if this is the first or the last fragment of the sent file.
+ *
+ * The multicast server uses the "qlog" option to produce Quic Logs as defined
  * in https://datatracker.ietf.org/doc/draft-marx-qlog-event-definitions-quic-h3/.
  * This is an optional feature, which requires linking with the "loglib" library,
- * and using the picoquic_set_qlog() API defined in "autoqlog.h". When a connection
+ * and using the picoquic_set_qlog() API defined in "autoqlog.h". . When a connection
  * completes, the code saves the log as a file named after the Initial Connection
- * ID (in hexa), with the suffix ".client.qlog".
+ * ID (in hexa), with the suffix ".server.qlog".
  */
 
 #include <stdint.h>
@@ -48,147 +39,50 @@
 #include <picoquic_packet_loop.h>
 #include "picoquic_multicast.h"
 
- /* Background thread management:
-  * 
-  * The "background" multicast is an example of application split
-  * between application threads for the application logic, and a
-  * background thread for the picoquic stack. 
-  * 
-  * In the "background client" mode, the files are requested from
-  * the UI thread, but the corresponding streams are created in the
-  * background thread. The shared state between the two
-  * threads is kept in the "background context", visible by
-  * both threads, and all interactions with the stack happen
-  * in the background thread, because the stack code is not
-  * thread safe.
-  * 
-  * The goal of the multicast is not to demonstrate distributed programming
-  * techniques. In a real application, the code running in the background
-  * would probably send messages and events to the application, but that
-  * kind of code is very application specific. In our multicast, we use a simple
-  * ad hoc coordination between the two threads:
-  * - the variable "nb_files" documents the number of files
-  *   that have been documented by the client. It is updated by
-  *   the UI thread when a new file is requested.
-  * - the variable "nb_files_processed" documents the number
-  *   of files for which a stream has been created. It is
-  *   updated by the UI thread.
-  * - the flag "is_closing_requested" is set by the application
-  *   when it wants to close the connection. The background thread
-  *   will call the `picoquic_close` API in the background thread,
-  *   set the flag `is_closing` after that, and set the flag
-  *   `is_disconnected` when the stack has completed the closing.
-  * After the application updates the shared state, it calls the
-  * API `picoquic_wake_up_network_thread`. This cause the background
-  * thread to stop waiting for packets or timeout, and to issue
-  * a loop callback `picoquic_packet_loop_wake_up`, during which the
-  * application provided call can interact safely with the
-  * picoquic stack.
-  */
-
-// static int multicast_sender_create_stream(picoquic_cnx_t* cnx,
-//     multicast_sender_ctx_t* client_ctx, int file_rank)
-// {
-//     int ret = 0;
-//     multicast_sender_stream_ctx_t* stream_ctx = (multicast_sender_stream_ctx_t*)
-//         malloc(sizeof(multicast_sender_stream_ctx_t));
-
-//     if (stream_ctx == NULL) {
-//         fprintf(stdout, "Memory Error, cannot create stream for file number %d\n", (int)file_rank);
-//         ret = -1;
-//     }
-//     else {
-//         memset(stream_ctx, 0, sizeof(multicast_sender_stream_ctx_t));
-//         if (client_ctx->first_stream == NULL) {
-//             client_ctx->first_stream = stream_ctx;
-//             client_ctx->last_stream = stream_ctx;
-//         }
-//         else {
-//             client_ctx->last_stream->next_stream = stream_ctx;
-//             client_ctx->last_stream = stream_ctx;
-//         }
-//         stream_ctx->file_rank = file_rank;
-//         stream_ctx->stream_id = picoquic_get_next_local_stream_id(client_ctx->cnx, 0);
-//         stream_ctx->name_length = strlen(client_ctx->file_names[file_rank]);
-
-//         /* Mark the stream as active. The callback will be asked to provide data when 
-//          * the connection is ready. */
-//         ret = picoquic_mark_active_stream(cnx, stream_ctx->stream_id, 1, stream_ctx);
-//         if (ret != 0) {
-//             fprintf(stdout, "Error %d, cannot initialize stream for file number %d\n", ret, (int)file_rank);
-//         }
-//     }
-
-//     return ret;
-// }
-
-static int multicast_sender_create_datagram(multicast_sender_ctx_t* sender_ctx)
+/* Create the application datagram context */
+static int multicast_sender_mark_datagram_ready(multicast_sender_ctx_t* sender_ctx)
 {
-    int ret = 0;
-    multicast_sender_datagram_ctx_t* datagram_ctx = (multicast_sender_datagram_ctx_t*)
-        malloc(sizeof(multicast_sender_datagram_ctx_t));
-
-        if (datagram_ctx == NULL) {
-        fprintf(stdout, "Memory Error, cannot create datagram for file\n");
-        ret = -1;
-    }
-    else {
-        memset(datagram_ctx, 0, sizeof(multicast_sender_datagram_ctx_t));
-        if (sender_ctx->first_datagram == NULL) {
-            sender_ctx->first_datagram = datagram_ctx;
-            sender_ctx->last_datagram = datagram_ctx;
-        }
-        else {
-            datagram_ctx->previous_datagram = sender_ctx->last_datagram;
-            sender_ctx->last_datagram->next_datagram = datagram_ctx;
-            sender_ctx->last_datagram = datagram_ctx;
-        }
-        datagram_ctx->name_length = strlen(sender_ctx->file_path);
-
-        /* Mark the stream as active. The callback will be asked to provide data when 
-        * the connection is ready. */
-        ret = picoquic_mark_datagram_ready_multicast(sender_ctx->mc_channel, 1);
-        if (ret != 0) {
-            fprintf(stdout, "Error %d, cannot mark datagram ready\n", ret);
-        }
+    /* Mark the stream as active. The callback will be asked to provide data when 
+    * the connection is ready. */
+    int ret = picoquic_mark_datagram_ready_multicast(sender_ctx->server_ctx->mc_channel, 1);
+    if (ret != 0) {
+        fprintf(stdout, "Error %d, cannot mark datagram ready\n", ret);
     }
 
     return ret;
 }
 
-int multicast_sender_open_file(multicast_sender_ctx_t* sender_ctx, multicast_sender_datagram_ctx_t* datagram_ctx)
+/* Open the file to be served via multicast */
+int multicast_sender_open_file(multicast_sender_ctx_t* sender_ctx)
 {
     int ret = 0;
     char file_path[1024];
 
-    /* Keep track that the full file name was acquired. */
-    // sender_ctx->is_name_read = 1;
-
     /* Verify the name, then try to open the file */
-    if (sizeof(sender_ctx->file_path) + 1 > sizeof(file_path)) {
+    if (sizeof(sender_ctx->server_ctx->served_filename) + 1 > sizeof(file_path)) {
         ret = PICOQUIC_MULTICAST_NAME_TOO_LONG_ERROR;
     }
     else {
         /* Use the picoquic_file_open API for portability to Windows and Linux */
-        datagram_ctx->F = picoquic_file_open(sender_ctx->file_path, "rb");
-        datagram_ctx->is_file_open = 1;
+        sender_ctx->F = picoquic_file_open(sender_ctx->server_ctx->served_filename, "rb");
+        sender_ctx->file_was_opened = 1;
 
-        if (datagram_ctx->F == NULL) {
+        if (sender_ctx->F == NULL) {
             ret = PICOQUIC_MULTICAST_NO_SUCH_FILE_ERROR;
         }
         else {
             /* Assess the file size, as this is useful for data planning */
             long sz;
-            fseek(datagram_ctx->F, 0, SEEK_END);
-            sz = ftell(datagram_ctx->F);
+            fseek(sender_ctx->F, 0, SEEK_END);
+            sz = ftell(sender_ctx->F);
 
             if (sz <= 0) {
-                datagram_ctx->F = picoquic_file_close(datagram_ctx->F);
+                sender_ctx->F = picoquic_file_close(sender_ctx->F);
                 ret = PICOQUIC_MULTICAST_FILE_READ_ERROR;
             }
             else {
-                datagram_ctx->file_length = (size_t)sz;
-                fseek(datagram_ctx->F, 0, SEEK_SET);
+                sender_ctx->file_length = (size_t)sz;
+                fseek(sender_ctx->F, 0, SEEK_SET);
                 ret = 0;
             }
         }
@@ -197,42 +91,10 @@ int multicast_sender_open_file(multicast_sender_ctx_t* sender_ctx, multicast_sen
     return ret;
 }
 
-static void multicast_sender_free_context(multicast_sender_ctx_t* sender_ctx)
-{
-    multicast_sender_datagram_ctx_t* datagram_ctx;
-
-    while ((datagram_ctx = sender_ctx->first_datagram) != NULL) {
-        sender_ctx->first_datagram = datagram_ctx->next_datagram;
-        if (datagram_ctx->F != NULL) {
-            (void)picoquic_file_close(datagram_ctx->F);
-        }
-        free(datagram_ctx);
-    }
-    sender_ctx->last_datagram = NULL;
-}
-
-void multicast_sender_delete_datagram_context(multicast_sender_ctx_t *sender_ctx, multicast_sender_datagram_ctx_t *datagram_ctx)
-{
-    /* Close the file if it was open */
-    if (datagram_ctx->F != NULL) {
-        datagram_ctx->F = picoquic_file_close(datagram_ctx->F);
-    }
-    /* Remove the context from the server's list */
-    if (datagram_ctx->previous_datagram == NULL) {
-        sender_ctx->first_datagram = datagram_ctx->next_datagram;
-    }
-    else {
-        datagram_ctx->previous_datagram->next_datagram = datagram_ctx->next_datagram;
-    }
-    if (datagram_ctx->next_datagram == NULL) {
-        sender_ctx->last_datagram = datagram_ctx->previous_datagram;
-    }
-    else {
-        datagram_ctx->next_datagram->previous_datagram = datagram_ctx->previous_datagram;
-    }
-
-    /* release the memory */
-    free(datagram_ctx);
+/* Schedule MC_LEAVE and MC_RETIRE frame to all clients to retire the channel */
+void picoquic_multicast_sender_retire(multicast_sender_ctx_t* sender_ctx) {
+    fprintf(stdout, "Nothing more to send, close channel with MC_LEAVE and MC_RETIRE\n");
+    picoquic_schedule_mc_leave_and_retire(sender_ctx->server_ctx->mc_channel);
 }
 
 int multicast_sender_callback(picoquic_multicast_channel_t* channel,
@@ -255,49 +117,49 @@ int multicast_sender_callback(picoquic_multicast_channel_t* channel,
         case picoquic_callback_stop_sending: 
         case picoquic_callback_stream_reset: 
         case picoquic_callback_stateless_reset:
-        case picoquic_callback_close: 
         case picoquic_callback_application_close:
         case picoquic_callback_stream_gap:
+        case picoquic_callback_almost_ready:
+        case picoquic_callback_ready:
+        case picoquic_callback_close: 
             // None of these events should happen, because we cannot receive anything
+            // and do not handle any unicast connections
             break;
         case picoquic_callback_prepare_to_send:
-            // Currently, no STREAM frames are sent, just DATAGRAMs
+            // Currently, no STREAM frames are sent, just DATAGRAMs - should not happen
             break;
         case picoquic_callback_prepare_datagram:
-            if (sender_ctx == NULL) {
-                // Should never happen
-                fprintf(stderr, "Sender context is null on picoquic_callback_prepare_datagram\n");
-                break;
-            }
-            else if (sender_ctx->first_datagram == NULL) {
-                fprintf(stdout, "Nothing more to send, finishing\n");
-                picoquic_mark_datagram_ready_multicast(sender_ctx->mc_channel, 0);
+
+            // File sending finished, stop sender loop and delete 
+            // thread at this point and notify server via callback
+            if (sender_ctx->file_sent >= sender_ctx->file_length && sender_ctx->file_was_opened) {
+                picoquic_mark_datagram_ready_multicast(sender_ctx->server_ctx->mc_channel, 0);
+                picoquic_multicast_sender_retire(sender_ctx);
                 break;
             }
 
-            multicast_sender_datagram_ctx_t* datagram_ctx = sender_ctx->first_datagram;
-            if (!datagram_ctx->is_file_open) {
-                ret = multicast_sender_open_file(sender_ctx, datagram_ctx);
+            if (!sender_ctx->file_was_opened && sender_ctx->F == NULL) {
+                ret = multicast_sender_open_file(sender_ctx);
                 if (ret != 0) {
                     fprintf(stderr, "Error while opening the requested file: %i\n", ret);
                     break;
                 }
             }
 
-            // Use 5-byte prefix and 5-byte suffix to indicate start and end of file to receiver
+            // Use header to indicate fragment number and first/last fragment
             int is_first = 0;
             int is_last = 0;
             int header_length = PICOQUIC_MULTICAST_DATAGRAM_HEADER_LENGTH;
 
             /* Implement the zero copy callback */
-            size_t available = datagram_ctx->file_length - datagram_ctx->file_sent + header_length;
+            size_t available = sender_ctx->file_length - sender_ctx->file_sent + header_length;
             int more_data = 0;
             uint8_t *buffer;
 
-            if (datagram_ctx->file_sent == 0 && datagram_ctx->fragment_number == 0) {
+            if (sender_ctx->file_sent == 0 && sender_ctx->current_fragment_number == 0) {
                 is_first = 1;
             } else {
-                datagram_ctx->fragment_number++;
+                sender_ctx->current_fragment_number++;
             }
             
             if (available > length) {
@@ -307,49 +169,53 @@ int multicast_sender_callback(picoquic_multicast_channel_t* channel,
                 is_last = 1;
             }
 
-            buffer = picoquic_provide_datagram_buffer_ex(bytes, available, picoquic_datagram_active_any_path);
-            if (buffer != NULL && available > PICOQUIC_MULTICAST_DATAGRAM_HEADER_LENGTH) {
-                uint8_t* start_fread = buffer;
+            if (available <= PICOQUIC_MULTICAST_DATAGRAM_HEADER_LENGTH) {
+                // Provided buffer is too small, request larger buffer from picoquic
+                picoquic_provide_datagram_buffer_ex(bytes, 0, picoquic_datagram_active_any_path);
+            } else {
+                buffer = picoquic_provide_datagram_buffer_ex(bytes, available, picoquic_datagram_active_any_path);
 
-                uint8_t first_byte = 0;
-                first_byte = first_byte | (uint8_t) is_last << (uint8_t) 0;
-                first_byte = first_byte | (uint8_t) is_first << (uint8_t) 1;
+                if (buffer != NULL) {
+                    uint8_t* start_fread = buffer;
 
-                memcpy(buffer, &first_byte, 1);
-                memcpy(buffer + 1, &(datagram_ctx->fragment_number), 8);
-                start_fread += header_length;
-                available -= header_length;
+                    uint8_t first_byte = 0;
+                    first_byte = first_byte | (uint8_t) is_last << (uint8_t) 0;
+                    first_byte = first_byte | (uint8_t) is_first << (uint8_t) 1;
 
-                if (is_last == 1 && is_first != 1) {
-                    fprintf(stdout, "is_last sent: First byte = 0x%x\n", buffer[0]);
-                } else if (is_last != 1 && is_first == 1) {
-                    fprintf(stdout, "is_first sent: First byte = 0x%x\n", buffer[0]);
-                } else if (is_last == 1 && is_first == 1) {
-                    fprintf(stdout, "is_first and is_last sent: First byte = 0x%x\n", buffer[0]);
-                }
+                    memcpy(buffer, &first_byte, 1);
+                    memcpy(buffer + 1, &(sender_ctx->current_fragment_number), PICOQUIC_MULTICAST_DATAGRAM_HEADER_LENGTH - 1);
+                    start_fread += header_length;
+                    available -= header_length;
 
-                size_t nb_read = fread(start_fread, 1, available, datagram_ctx->F);
+                    if (is_last == 1 && is_first != 1) {
+                        fprintf(stdout, "is_last sent: First byte = 0x%x\n", buffer[0]);
+                    } else if (is_last != 1 && is_first == 1) {
+                        fprintf(stdout, "is_first sent: First byte = 0x%x\n", buffer[0]);
+                    } else if (is_last == 1 && is_first == 1) {
+                        fprintf(stdout, "is_first and is_last sent: First byte = 0x%x\n", buffer[0]);
+                    }
 
-                if (nb_read != available) {
-                    /* Error while reading the file */
-                    ret = -1;           
+                    size_t nb_read = fread(start_fread, 1, available, sender_ctx->F);
+
+                    if (nb_read != available) {
+                        /* Error while reading the file */
+                        ret = -1;           
+                    }
+                    else {
+                        sender_ctx->file_sent += nb_read;
+                    }
                 }
                 else {
-                    datagram_ctx->file_sent += nb_read;
+                    /* Should never happen according to callback spec. */
+                    ret = -1;
+                }
+
+                // File sending finished, stop sender loop and delete 
+                // thread at this point and notify server via callback
+                if (!more_data) {
+                    picoquic_multicast_sender_retire(sender_ctx);
                 }
             }
-            else {
-                /* Should never happen according to callback spec. */
-                ret = -1;
-            }
-
-            if (!more_data) {
-                multicast_sender_delete_datagram_context(sender_ctx, datagram_ctx);
-            }
-            break;
-        case picoquic_callback_almost_ready:
-            break;
-        case picoquic_callback_ready:
             break;
         default:
             /* unexpected -- just ignore. */
@@ -360,192 +226,57 @@ int multicast_sender_callback(picoquic_multicast_channel_t* channel,
     return ret;
 }
 
-/* Prepare the context used by the multicast sender client:
- * - Create the QUIC context.
- * - Open the socket
- * - Find the server's address
- * - Prepare the multicast channel
- */
-static int multicast_sender_init(int server_port, const char *server_cert, const char *server_key, 
-    char const* file_path, picoquic_quic_t** quic, multicast_sender_ctx_t *sender_ctx,
+/* Prepare the context used by the multicast sender client and set callback */
+static int multicast_sender_init(multicast_sender_ctx_t *sender_ctx,
     picoquic_multicast_channel_t* channel)
 {
     int ret = 0;
-    char const* qlog_dir = PICOQUIC_MULTICAST_CLIENT_QLOG_DIR;
-    uint64_t current_time = picoquic_current_time();
 
-    *quic = NULL;
+    char text1[256];
+    printf("Prepare multicast sending for group ip %s\n", 
+        picoquic_addr_text((struct sockaddr*)&channel->group_ip, text1, sizeof(text1))
+    );
 
-    /* Create a QUIC context and:
-     * - enable logging of encryption keys for wireshark debugging.
-     * - instantiate a binary log option, and log all packets.
-     */
-    if (ret == 0) {
-        *quic = picoquic_create(PICOQUIC_MULTICAST_MAX_CLIENTS, server_cert, server_key, NULL, PICOQUIC_MULTICAST_ALPN, 
-            NULL, NULL, NULL, NULL, NULL, current_time, NULL, NULL, NULL, 0);
+    /* Set the callback context */
+    picoquic_set_callback_multicast(channel, multicast_sender_callback, sender_ctx);
 
-        if (*quic == NULL) {
-            fprintf(stderr, "Could not create quic context\n");
-            ret = -1;
-        }
-        else {
-            picoquic_set_key_log_file_from_env(*quic);
-            picoquic_set_qlog(*quic, qlog_dir);
-            picoquic_set_log_level(*quic, 1);
-            sender_ctx->quic = *quic;
-        }
-    }
-    /* Initialize the callback context */
-    if (ret == 0) {
-        char text1[256];
-        printf("Prepare multicast sending for group ip %s\n", 
-            picoquic_addr_text((struct sockaddr*)&channel->group_ip, text1, sizeof(text1))
-        );
-
-        /* Set the callback context */
-        picoquic_set_callback_multicast(channel, multicast_sender_callback, sender_ctx);
-    }
-
-    return ret;
-}
-
-/* Loop callback for the background client.
-* 
-* The main difference with the simpler loop used for the basic client
-* is the support for the "wake up" callback, which we use to create
-* streams inside the background thread because the picoquic code
-* is not generally thread safe.
-* 
-* The support for the wakeup call is declared 
-* 
-* 
-* In the "background client" mode, the files are requested from
-* the UI thread, but the corresponding streams are created in the
-* background thread. We use a very simple thread coordination
-* process to keep the multicast simple:
-* - the variable "nb_files" documents the number of files
-*   that have been documented by the client. It is updated by
-*   the UI thread when a new file is requested.
-* - the variable "nb_files_processed" documents the number
-*   of files for which a stream has been created. It is
-*   updated by the UI thread.
-* This is implemented in the "multicast process wakeup" function.
-*/
-// static int multicast_sender_wakeup(multicast_sender_ctx_t* client_ctx)
-// {
-//     int ret = 0;
-
-//     while (client_ctx->nb_files > client_ctx->nb_files_processed) {
-//         ret = multicast_sender_create_stream(client_ctx->cnx, client_ctx, client_ctx->nb_files_processed);
-//         if (ret < 0) {
-//             fprintf(stderr, "\nCould not initiate stream for file #%d, %s\n", 
-//                 client_ctx->nb_files_processed,
-//                 client_ctx->file_names[client_ctx->nb_files_processed]);
-//             break;
-//         }
-//         client_ctx->nb_files_processed++;
-//     }
-
-//     // if (client_ctx->is_closing_requested && !client_ctx->is_closing) {
-//     //     picoquic_close(client_ctx->cnx, 0);
-//     // }
-
-//     return ret;
-// }
-
-// TODO MC: Is this callback needed?
-static int multicast_sender_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, 
-    void* callback_ctx, void * callback_arg)
-{
-    int ret = 0;
-    multicast_sender_ctx_t* sender_ctx = (multicast_sender_ctx_t*)callback_ctx;
-
-    if (sender_ctx == NULL) {
-        ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
-    }
-    else {
-        switch (cb_mode) {
-        case picoquic_packet_loop_ready:
-            break;
-        case picoquic_packet_loop_wake_up:
-            // ret = multicast_sender_wakeup(client_ctx);
-            break;
-        case picoquic_packet_loop_after_receive:
-            break;
-        case picoquic_packet_loop_after_send:
-            if (sender_ctx->is_disconnected) {
-                ret = PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
-            }
-            break;
-        case picoquic_packet_loop_port_update:
-            break;
-        default:
-            ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
-            break;
-        }
-    }
     return ret;
 }
 
 /* Start multicast sender server */
-int picoquic_multicast_sender_start(int server_port, 
-    const char* server_cert, const char* server_key,
-    char const* file_path, 
-    picoquic_multicast_channel_t* channel, picoquic_network_thread_ctx_t** thread_ctx,
-    multicast_sender_ctx_t* sender_ctx
-) {
+int picoquic_multicast_sender_start(multicast_sender_ctx_t* sender_ctx) {
     int ret = 0;
-    picoquic_quic_t* quic = NULL;
     int thread_ret = 0;
     picoquic_packet_loop_param_t param = { 0 };
+    multicast_server_ctx_t* server_ctx = sender_ctx->server_ctx;
 
-    ret = multicast_sender_init(server_port, server_cert, server_key, 
-        file_path, &quic, sender_ctx, channel);
+    ret = multicast_sender_init(sender_ctx, server_ctx->mc_channel);
 
-    /* Initialize the file path field */
-    sender_ctx->file_path = file_path;
+    /* Initialize the callback context */
+    char text1[256];
+    printf("Prepare multicast sending for group ip %s\n", 
+        picoquic_addr_text((struct sockaddr*)&server_ctx->mc_channel->group_ip, text1, sizeof(text1))
+    );
 
-    /* Save the multicast channel pointer */
-    sender_ctx->mc_channel = channel;
-
-    /* Set the multicast channel for this thread */
-    param.multicast_channel = channel;
-
-    /* Set the multicast sender port for this thread */
-    param.local_port = server_port;
-
-    /* Force 127.0.0.1 as src ip for multicast packets for local tests */
-    param.force_localhost_src_ip = 1;
+    /* Set the params for this thread */
+    param.multicast_channel = server_ctx->mc_channel;
+    param.local_port = server_ctx->sender_port;
+    param.force_localhost_src_ip = 1; /* Force localhost as src ip for multicast packets for local tests */
 
     // CHECK MC: GSO deactivated currently due to issues with local interfaces, may be re-activated later?
     param.do_not_use_gso = 1;
 
+    /* Set the callback context */
+    picoquic_set_callback_multicast(server_ctx->mc_channel, multicast_sender_callback, sender_ctx);
+
     /* Start the background thread. */
-    *thread_ctx = picoquic_start_custom_network_thread_ex(quic, &param,
+    sender_ctx->thread_ctx = picoquic_start_custom_network_thread_ex(server_ctx->quic, &param,
         picoquic_internal_thread_create, picoquic_internal_thread_delete,
         picoquic_internal_thread_setname, "multicast_sender", 
         picoquic_packet_loop_multicast_send,
-        multicast_sender_loop_cb,
-        sender_ctx, &thread_ret);
+        NULL, NULL, &thread_ret);
 
-    ret = multicast_sender_create_datagram(sender_ctx);
+    ret = multicast_sender_mark_datagram_ready(sender_ctx);
 
     return ret;
-}
-
-/* Stop multicast sender server and cleanup */
-void picoquic_multicast_sender_stop(picoquic_network_thread_ctx_t* thread_ctx, multicast_sender_ctx_t* sender_ctx) {
-    picoquic_quic_t* quic = sender_ctx->quic;
-    
-    /* close the network thread. */
-    picoquic_delete_network_thread(thread_ctx);
-    thread_ctx = NULL;
-
-    /* Save tickets and tokens, and free the QUIC context */
-    if (quic != NULL) {
-        picoquic_free(quic);
-    }
-
-    /* Free the Client context */
-    multicast_sender_free_context(sender_ctx);
 }

--- a/multicast_sample/multicast_server.c
+++ b/multicast_sample/multicast_server.c
@@ -1,37 +1,28 @@
-/*
- * Author: Christian Huitema
- * Copyright (c) 2020, Private Octopus, Inc.
- * All rights reserved.
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
-/* The "multicast" project builds a simple file transfer program that can be
- * instantiated in client or server mode. The "multicast_server" implements
+/* The "multicast" project builds a simple multicast application that can be
+ * instantiated in client or server mode. The "multicast_server" and "multicast_sender" implements
  * the server components of the multicast application.
  *
- * Developing the server requires two main components:
- *  - the server "callback" that implements the server side of the
- *    application protocol, managing a server side application context
- *    for each connection.
- *  - the server loop, that reads messages on the socket, submits them
- *    to the Quic context, let the server prepare messages, and send
- *    them on the appropriate socket.
+ * The server currently works using two components:
+ * 
+ *  - the multicast control server (multicast_server.c) records the multicast channel state
+ *    of the clients (joined/left) and handles the lifecycle of the multicast sender (start, stop).
+ *    It is started directly when "multicast server <params>" is executed, initializes picoquic,
+ *    sets the picoquic callbacks for client interaction and starts the packet loop.
  *
- * The Multicast Server uses the "qlog" option to produce Quic Logs as defined
+ *  - the multicast sender (multicast_sender.c) runs in a separate thread within the server application
+ *    and is started by the control server, once a specified threshold of clients is reached 
+ *    (clients_threshold CLI parameter). The sender runs with the same quic context as the control 
+ *    server and "stupidly" sends out data from a file specified by the control server via a special 
+ *    send-only packet loop. Once the sender is finished with sending the file, it calls a specified 
+ *    callback in the control server. The control server then invokes retiring of all clients for that 
+ *    multicast chanenl and stops the sender thread.
+ * 
+ * The multicast sender currently only sends out DATAGRAM frames contining the specified file,
+ * where each DATAGRAM frame contains a small custom application header defining a "fragment number"
+ * (so that the clients can rearrange the DATAGRAM frames into the correct order again) and an indicator
+ * if this is the first or the last fragment of the sent file.
+ *
+ * The multicast server uses the "qlog" option to produce Quic Logs as defined
  * in https://datatracker.ietf.org/doc/draft-marx-qlog-event-definitions-quic-h3/.
  * This is an optional feature, which requires linking with the "loglib" library,
  * and using the picoquic_set_qlog() API defined in "autoqlog.h". . When a connection
@@ -49,197 +40,86 @@
 #include "picoquic_multicast.h"
 #include "picoquic_packet_loop.h"
 
-/* Server context and callback management:
- *
- * The server side application context is created for each new connection,
- * and is freed when the connection is closed. It contains a list of
- * server side stream contexts, one for each stream open on the
- * connection. Each stream context includes:
- *  - description of the stream state:
- *      name_read or not, FILE open or not, stream reset or not,
- *      stream finished or not.
- *  - the number of file name bytes already read.
- *  - the name of the file requested by the client.
- *  - the FILE pointer for reading the data.
- * Server side stream context is created when the client starts the
- * stream. It is closed when the file transmission
- * is finished, or when the stream is abandoned.
- *
+typedef struct st_multicast_server_cnx_ctx_t
+{
+    multicast_server_ctx_t* global_ctx;
+    int is_joined;
+    int is_active;
+} multicast_server_cnx_ctx_t;
+
+/* Delete sender context */
+void multicast_server_delete_sender_context(multicast_sender_ctx_t *sender_ctx)
+{
+    picoquic_delete_network_thread(sender_ctx->thread_ctx);
+    sender_ctx->thread_ctx = NULL;
+
+    /* free the sender application context */
+    if (sender_ctx->F != NULL) {
+        (void)picoquic_file_close(sender_ctx->F);
+    }
+}
+
+/* Server proactively removes a specific client from channel */
+// CHECK MC: Currently, this is not used, and also not needed in the example application,
+// as all clients are removed at once after the file transfer is finished using picoquic_schedule_mc_leave_and_retire
+void multicast_server_remove_client_from_channel(multicast_server_cnx_ctx_t* server_cnx_ctx, picoquic_cnx_t* cnx) {
+    multicast_server_ctx_t* server_ctx = server_cnx_ctx->global_ctx;
+
+    if (server_cnx_ctx == NULL || server_ctx == NULL) {
+        // error
+        fprintf(stderr, "Error: Client could not be removed from channel\n");
+        return;
+    }
+
+    if (server_ctx->nb_joined_clients > 0) {
+        picoquic_schedule_mc_leave(server_ctx->mc_channel, cnx);
+    } else {
+        picoquic_schedule_mc_retire(server_ctx->mc_channel, cnx);
+    }
+    if (server_cnx_ctx->is_active) {
+        server_cnx_ctx->is_active = 0;
+        server_ctx->nb_active_clients--;
+    }
+}
+
+/* Handle STATE(LEFT) or STATE(RETIRED) from client */
+void multicast_server_process_client_left_or_retired(multicast_server_cnx_ctx_t* server_cnx_ctx, picoquic_cnx_t* cnx) {
+    multicast_server_ctx_t* server_ctx = server_cnx_ctx->global_ctx;
+
+    if (server_cnx_ctx->is_active) {
+        server_cnx_ctx->is_active = 0;
+        server_ctx->nb_active_clients--;
+    }
+    if (server_cnx_ctx->is_joined) {
+        server_cnx_ctx->is_joined = 0;
+        server_ctx->nb_joined_clients--;
+    }
+
+    free(server_cnx_ctx);
+    picoquic_set_callback(cnx, NULL, NULL);
+    
+    // Stop multicast sender if all clients are already left
+    if (server_ctx != NULL && server_ctx->nb_joined_clients == 0 && server_ctx->mc_channel->is_retired) {
+        server_ctx->is_closing = 1;
+    }
+}
+
+/*
  * The server side callback is a large switch statement, with one entry
  * for each of the call back events.
  */
-
-typedef struct st_multicast_server_datagram_ctx_t
-{
-    struct st_multicast_server_datagram_ctx_t *next_datagram;
-    struct st_multicast_server_datagram_ctx_t *previous_datagram;
-    uint64_t datagram_id;
-    FILE *F;
-    uint8_t file_name[256];
-    size_t name_length;
-    size_t file_length;
-    size_t file_sent;
-    unsigned int is_name_read : 1;
-    unsigned int is_datagram_reset : 1;
-    unsigned int is_datagram_finished : 1;
-} multicast_server_datagram_ctx_t;
-
-typedef struct st_multicast_server_ctx_t
-{
-    char const *served_file;
-    size_t served_file_len;
-    multicast_server_datagram_ctx_t *first_datagram;
-    multicast_server_datagram_ctx_t *last_datagram;
-    picoquic_multicast_channel_t *mc_channel;
-    // ENHANCE MC Maybe: save cnx pointers instead of, to really identify clients
-    int joined_clients;
-    int active_clients; 
-    picoquic_network_thread_ctx_t* sender_thread_ctx;
-    multicast_sender_ctx_t sender_app_ctx;
-    int sender_running;
-    const char *server_cert; 
-    const char *server_key;
-    int sender_port;
-} multicast_server_ctx_t;
-
-multicast_server_datagram_ctx_t *multicast_server_create_datagram_context(multicast_server_ctx_t *server_ctx, uint64_t datagram_id)
-{
-    multicast_server_datagram_ctx_t *datagram_ctx = (multicast_server_datagram_ctx_t *)malloc(sizeof(multicast_server_datagram_ctx_t));
-
-    if (datagram_ctx != NULL)
-    {
-        memset(datagram_ctx, 0, sizeof(multicast_server_datagram_ctx_t));
-
-        if (server_ctx->last_datagram == NULL)
-        {
-            server_ctx->last_datagram = datagram_ctx;
-            server_ctx->first_datagram = datagram_ctx;
-        }
-        else
-        {
-            datagram_ctx->previous_datagram = server_ctx->last_datagram;
-            server_ctx->last_datagram->next_datagram = datagram_ctx;
-            server_ctx->last_datagram = datagram_ctx;
-        }
-        datagram_ctx->datagram_id = datagram_id;
-    }
-
-    return datagram_ctx;
-}
-
-int multicast_server_open_file(multicast_server_ctx_t *server_ctx, multicast_server_datagram_ctx_t *datagram_ctx)
-{
-    int ret = 0;
-    char file_path[1024];
-
-    /* Keep track that the full file name was acquired. */
-    datagram_ctx->is_name_read = 1;
-
-    /* Verify the name, then try to open the file */
-    if (server_ctx->served_file_len + 1 > sizeof(file_path))
-    {
-        ret = PICOQUIC_MULTICAST_NAME_TOO_LONG_ERROR;
-    }
-    else
-    {
-        size_t path_len = server_ctx->served_file_len;
-        if (path_len > 0)
-        {
-            memcpy(file_path, server_ctx->served_file, path_len);
-        }
-        file_path[path_len] = 0;
-
-        /* Use the picoquic_file_open API for portability to Windows and Linux */
-        datagram_ctx->F = picoquic_file_open(file_path, "rb");
-
-        if (datagram_ctx->F == NULL)
-        {
-            ret = PICOQUIC_MULTICAST_NO_SUCH_FILE_ERROR;
-        }
-        else
-        {
-            /* Assess the file size, as this is useful for data planning */
-            long sz;
-            fseek(datagram_ctx->F, 0, SEEK_END);
-            sz = ftell(datagram_ctx->F);
-
-            if (sz <= 0)
-            {
-                datagram_ctx->F = picoquic_file_close(datagram_ctx->F);
-                ret = PICOQUIC_MULTICAST_FILE_READ_ERROR;
-            }
-            else
-            {
-                datagram_ctx->file_length = (size_t)sz;
-                fseek(datagram_ctx->F, 0, SEEK_SET);
-                ret = 0;
-            }
-        }
-    }
-
-    return ret;
-}
-
-void multicast_server_delete_stream_context(multicast_server_ctx_t *server_ctx, multicast_server_datagram_ctx_t *datagram_ctx)
-{
-    /* Close the file if it was open */
-    if (datagram_ctx->F != NULL)
-    {
-        datagram_ctx->F = picoquic_file_close(datagram_ctx->F);
-    }
-
-    /* Remove the context from the server's list */
-    if (datagram_ctx->previous_datagram == NULL)
-    {
-        server_ctx->first_datagram = datagram_ctx->next_datagram;
-    }
-    else
-    {
-        datagram_ctx->previous_datagram->next_datagram = datagram_ctx->next_datagram;
-    }
-
-    if (datagram_ctx->next_datagram == NULL)
-    {
-        server_ctx->last_datagram = datagram_ctx->previous_datagram;
-    }
-    else
-    {
-        datagram_ctx->next_datagram->previous_datagram = datagram_ctx->previous_datagram;
-    }
-
-    /* release the memory */
-    free(datagram_ctx);
-}
-
-void multicast_server_delete_context(multicast_server_ctx_t *server_ctx)
-{
-    /* Delete any remaining stream context */
-    while (server_ctx->first_datagram != NULL)
-    {
-        multicast_server_delete_stream_context(server_ctx, server_ctx->first_datagram);
-    }
-
-    /* release the memory */
-    free(server_ctx);
-}
-
 int multicast_server_callback(picoquic_cnx_t *cnx,
                               uint64_t stream_id, uint8_t *bytes, size_t length,
                               picoquic_call_back_event_t fin_or_event, void *callback_ctx, void *v_stream_ctx)
 {
     int ret = 0;
-    multicast_server_ctx_t *server_ctx = (multicast_server_ctx_t *)callback_ctx;
-    // CHECK MC: Use datagram context?
-    // multicast_server_datagram_ctx_t *datagram_ctx = (multicast_server_datagram_ctx_t *)v_stream_ctx;
-
-    /* If this is the first reference to the connection, the application context is set
-     * to the default value defined for the server. This default value contains the pointer
-     * to the file directory in which all files are defined.
-     */
+    multicast_server_cnx_ctx_t *server_cnx_ctx = (multicast_server_cnx_ctx_t *)callback_ctx;
+    multicast_server_ctx_t *server_ctx = server_cnx_ctx->global_ctx;
+    
     if (callback_ctx == NULL || callback_ctx == picoquic_get_default_callback_context(picoquic_get_quic_ctx(cnx)))
     {
-        server_ctx = (multicast_server_ctx_t *)malloc(sizeof(multicast_server_ctx_t));
-        if (server_ctx == NULL)
+        server_cnx_ctx = (multicast_server_cnx_ctx_t *)malloc(sizeof(multicast_server_cnx_ctx_t));
+        if (server_cnx_ctx == NULL)
         {
             /* cannot handle the connection */
             picoquic_close(cnx, PICOQUIC_ERROR_MEMORY);
@@ -247,18 +127,17 @@ int multicast_server_callback(picoquic_cnx_t *cnx,
         }
         else
         {
-            multicast_server_ctx_t *d_ctx = (multicast_server_ctx_t *)picoquic_get_default_callback_context(picoquic_get_quic_ctx(cnx));
+            multicast_server_cnx_ctx_t *d_ctx = (multicast_server_cnx_ctx_t *)picoquic_get_default_callback_context(picoquic_get_quic_ctx(cnx));
             if (d_ctx != NULL)
             {
-                memcpy(server_ctx, d_ctx, sizeof(multicast_server_ctx_t));
+                memcpy(server_cnx_ctx, d_ctx, sizeof(multicast_server_cnx_ctx_t));
             }
             else
             {
                 /* This really is an error case: the default connection context should never be NULL */
-                memset(server_ctx, 0, sizeof(multicast_server_ctx_t));
-                server_ctx->served_file = "";
+                memset(server_cnx_ctx, 0, sizeof(multicast_server_cnx_ctx_t));
             }
-            picoquic_set_callback(cnx, multicast_server_callback, server_ctx);
+            picoquic_set_callback(cnx, multicast_server_callback, server_cnx_ctx);
         }
     }
 
@@ -268,136 +147,23 @@ int multicast_server_callback(picoquic_cnx_t *cnx,
         {
         case picoquic_callback_stream_data:
         case picoquic_callback_stream_fin:
-            // /* Data arrival on stream #x, maybe with fin mark */
-            // if (stream_ctx == NULL)
-            // {
-            //     /* Create and initialize stream context */
-            //     stream_ctx = multicast_server_create_stream_context(server_ctx, stream_id);
-            //     if (picoquic_set_app_stream_ctx(cnx, stream_id, stream_ctx) != 0)
-            //     {
-            //         /* Internal error */
-            //         (void)picoquic_reset_stream(cnx, stream_id, PICOQUIC_MULTICAST_INTERNAL_ERROR);
-            //         return (-1);
-            //     }
-            // }
-
-            // if (stream_ctx == NULL)
-            // {
-            //     /* Internal error */
-            //     (void)picoquic_reset_stream(cnx, stream_id, PICOQUIC_MULTICAST_INTERNAL_ERROR);
-            //     return (-1);
-            // }
-            // else if (stream_ctx->is_name_read)
-            // {
-            //     /* Write after fin? */
-            //     return (-1);
-            // }
-            // else
-            // {
-            //     /* Accumulate data */
-            //     size_t available = sizeof(stream_ctx->file_name) - stream_ctx->name_length - 1;
-
-            //     if (length > available)
-            //     {
-            //         /* Name too long: reset stream! */
-            //         multicast_server_delete_stream_context(server_ctx, stream_ctx);
-            //         (void)picoquic_reset_stream(cnx, stream_id, PICOQUIC_MULTICAST_NAME_TOO_LONG_ERROR);
-            //     }
-            //     else
-            //     {
-            //         if (length > 0)
-            //         {
-            //             memcpy(stream_ctx->file_name + stream_ctx->name_length, bytes, length);
-            //             stream_ctx->name_length += length;
-            //         }
-            //         if (fin_or_event == picoquic_callback_stream_fin)
-            //         {
-            //             int stream_ret;
-
-            //             /* If fin, mark read, check the file, open it. Or reset if there is no such file */
-            //             stream_ctx->file_name[stream_ctx->name_length + 1] = 0;
-            //             stream_ctx->is_name_read = 1;
-            //             printf("File requested: <%s>\n", stream_ctx->file_name);
-            //             stream_ret = multicast_server_open_stream(server_ctx, stream_ctx);
-
-            //             if (stream_ret == 0)
-            //             {
-            //                 /* If data needs to be sent, set the context as active */
-            //                 ret = picoquic_mark_active_stream(cnx, stream_id, 1, stream_ctx);
-            //             }
-            //             else
-            //             {
-            //                 /* If the file could not be read, reset the stream */
-            //                 multicast_server_delete_stream_context(server_ctx, stream_ctx);
-            //                 (void)picoquic_reset_stream(cnx, stream_id, stream_ret);
-            //             }
-            //         }
-            //     }
-            // }
-            // break;
+            // STREAM data arrived. Should not be the case here
+            break;
         case picoquic_callback_prepare_to_send:
-
-            // /* Active sending API */
-            // if (stream_ctx == NULL)
-            // {
-            //     /* This should never happen */
-            // }
-            // else if (stream_ctx->F == NULL)
-            // {
-            //     /* Error, asking for data after end of file */
-            // }
-            // else
-            // {
-            //     /* Implement the zero copy callback */
-            //     size_t available = stream_ctx->file_length - stream_ctx->file_sent;
-            //     int is_fin = 1;
-            //     uint8_t *buffer;
-
-            //     if (available > length)
-            //     {
-            //         available = length;
-            //         is_fin = 0;
-            //     }
-
-            //     buffer = picoquic_provide_stream_data_buffer(bytes, available, is_fin, !is_fin);
-            //     if (buffer != NULL)
-            //     {
-            //         size_t nb_read = fread(buffer, 1, available, stream_ctx->F);
-
-            //         if (nb_read != available)
-            //         {
-            //             /* Error while reading the file */
-            //             multicast_server_delete_stream_context(server_ctx, stream_ctx);
-            //             (void)picoquic_reset_stream(cnx, stream_id, PICOQUIC_MULTICAST_FILE_READ_ERROR);
-            //         }
-            //         else
-            //         {
-            //             stream_ctx->file_sent += available;
-            //         }
-            //     }
-            //     else
-            //     {
-            //         /* Should never happen according to callback spec. */
-            //         ret = -1;
-            //     }
-            // }
-            // break;
+            // STREAM data should be send. Not the case here
+            break;
         case picoquic_callback_stream_reset: /* Client reset stream #x */
         case picoquic_callback_stop_sending: /* Client asks server to reset stream #x */
-            // if (stream_ctx != NULL)
-            // {
-            //     /* Mark stream as abandoned, close the file, etc. */
-            //     multicast_server_delete_stream_context(server_ctx, stream_ctx);
-            //     picoquic_reset_stream(cnx, stream_id, PICOQUIC_MULTICAST_FILE_CANCEL_ERROR);
-            // }
-            // break;
         case picoquic_callback_stateless_reset:   /* Received an error message */
         case picoquic_callback_close:             /* Received connection close */
         case picoquic_callback_application_close: /* Received application close */
-            /* Delete the server application context */
-            picoquic_multicast_sender_stop(server_ctx->sender_thread_ctx, &server_ctx->sender_app_ctx);
-            multicast_server_delete_context(server_ctx);
-            picoquic_set_callback(cnx, NULL, NULL);
+            // Treat all of this as if the client would have sent STATE(LEFT) or STATE(RETIRED)
+            multicast_server_process_client_left_or_retired(server_cnx_ctx, cnx);
+            if (server_ctx != NULL) {
+                fprintf(stdout, "Callback to close a connection, joined clients new: %i\n", server_ctx->nb_joined_clients);
+            } else {
+                fprintf(stdout, "Callback to close a connection, nobody left, stopping.\n");
+            }
             break;
         case picoquic_callback_version_negotiation:
             /* The server should never receive a version negotiation response */
@@ -409,35 +175,43 @@ int multicast_server_callback(picoquic_cnx_t *cnx,
         case picoquic_callback_ready:
             /* Check that the transport parameters are what the multicast expects */
             if (cnx->is_multicast_enabled == 1 && server_ctx->mc_channel != NULL && cnx->nb_mc_channels == 0 
-                && server_ctx->joined_clients < PICOQUIC_MULTICAST_MAX_CLIENTS) {
+                && server_ctx->nb_joined_clients < PICOQUIC_MULTICAST_MAX_CLIENTS) {
                 // send announce, key and join frame to client
+                server_cnx_ctx->is_joined = 1;
+                server_ctx->nb_joined_clients++;
                 picoquic_schedule_mc_announce_and_join(cnx, server_ctx->mc_channel);
-                server_ctx->joined_clients++;
             }
+            fprintf(stdout, "Callback picoquic_callback_ready, joined clients new: %i\n", server_ctx->nb_joined_clients);
             break;
         case picoquic_callback_multicast_join_attempted:
             // If data sending on multicast channel did not start yet, start now
-            if (!server_ctx->sender_running) {
-                int err = picoquic_multicast_sender_start(server_ctx->sender_port, 
-                    server_ctx->server_cert, server_ctx->server_key, server_ctx->served_file, 
-                    server_ctx->mc_channel, &server_ctx->sender_thread_ctx, &server_ctx->sender_app_ctx
-                );
+            fprintf(stdout, "Callback picoquic_callback_multicast_join_attempted, joined clients: %i, threshold: %i\n", server_ctx->nb_joined_clients, server_ctx->client_threshold);
+            if (!server_ctx->sender_running && server_ctx->nb_joined_clients >= server_ctx->client_threshold) {
+                int err = picoquic_multicast_sender_start(&server_ctx->sender_app_ctx);
                 if (err == 0) {
                     server_ctx->sender_running = 1;
-                     fprintf(stdout, "Multicast sender started\n");
+                    fprintf(stdout, "Multicast sender started\n");
                 } else {
                     fprintf(stderr, "Error while starting multicast sender: %i\n", err);
                 }
             }
-            
             break;
         case picoquic_callback_multicast_join_confirmed: 
             // TODO MC: currently not implemented (when MC_ACK is received)
-            server_ctx->active_clients++;
+            server_cnx_ctx->is_active = 1;
+            server_ctx->nb_active_clients++;
+            fprintf(stdout, "Callback picoquic_callback_multicast_join_confirmed, active clients new: %i\n", server_ctx->nb_active_clients);
             break;
         case picoquic_callback_multicast_left:
-            server_ctx->active_clients--;
-            server_ctx->joined_clients--;
+        case picoquic_callback_multicast_retired:
+            // Client has sent STATE(LEFT) or STATE(RETIRED)
+            // ENHANCE MC: Differentiation between STATE(LEFT) and STATE(RETIRED) needed?
+            multicast_server_process_client_left_or_retired(server_cnx_ctx, cnx);
+            if (server_ctx != NULL) {
+                fprintf(stdout, "Callback to close a connection, joined clients new: %i\n", server_ctx->nb_joined_clients);
+            } else {
+                fprintf(stdout, "Callback to close a connection, nobody left, stopping.\n");
+            }
             break;
         default:
             /* unexpected */
@@ -445,6 +219,35 @@ int multicast_server_callback(picoquic_cnx_t *cnx,
         }
     }
 
+    return ret;
+}
+
+static int multicast_server_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, 
+    void* callback_ctx, void * callback_arg)
+{
+    int ret = 0;
+    multicast_server_ctx_t* server_ctx = (multicast_server_ctx_t*)callback_ctx;
+
+    if (server_ctx == NULL) {
+        ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
+    }
+    else {
+        switch (cb_mode) {
+        case picoquic_packet_loop_ready:
+        case picoquic_packet_loop_wake_up:
+        case picoquic_packet_loop_after_receive:
+        case picoquic_packet_loop_port_update:
+            break;
+        case picoquic_packet_loop_after_send:
+            if (server_ctx->is_closing) {
+                ret = PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+            }
+            break;
+        default:
+            ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
+            break;
+        }
+    }
     return ret;
 }
 
@@ -460,22 +263,25 @@ int multicast_server_callback(picoquic_cnx_t *cnx,
  * - The loop breaks if the socket return an error.
  */
 
-int picoquic_multicast_server(int server_port, int sender_port, const char *server_cert, const char *server_key, int max_rate, const char *served_file)
+int picoquic_multicast_server(int server_port, int sender_port, const char *server_cert, const char *server_key, int max_rate, const char *served_file, int client_threshold)
 {
-    // TODO MC: Start background thread mc sender server in this method somewhere
-
     /* Start: start the QUIC process with cert and key files */
     int ret = 0;
     picoquic_quic_t *quic = NULL;
     char const *qlog_dir = PICOQUIC_MULTICAST_SERVER_QLOG_DIR;
     uint64_t current_time = 0;
-    multicast_server_ctx_t default_context = {0};
+    multicast_server_cnx_ctx_t default_context = {0}; // Per connection context
+    multicast_server_ctx_t global_ctx = {0}; // Application global context
 
-    default_context.served_file = served_file;
-    default_context.served_file_len = strlen(served_file);
-    default_context.server_cert = server_cert;
-    default_context.server_key = server_key;
-    default_context.sender_port = sender_port;
+    global_ctx.served_filename = served_file;
+    global_ctx.server_cert = server_cert;
+    global_ctx.server_key = server_key;
+    global_ctx.sender_port = sender_port;
+    global_ctx.client_threshold = client_threshold;
+    global_ctx.quic = quic;
+    global_ctx.sender_app_ctx.server_ctx = &global_ctx;
+
+    default_context.global_ctx = &global_ctx;
 
     printf("Starting Picoquic Multicast server on port %d\n", server_port);
     printf("Serving file %s\n", served_file);
@@ -494,15 +300,10 @@ int picoquic_multicast_server(int server_port, int sender_port, const char *serv
     else
     {
         picoquic_set_cookie_mode(quic, 2);
-
         picoquic_set_default_congestion_algorithm(quic, picoquic_bbr_algorithm);
-
         picoquic_set_qlog(quic, qlog_dir);
-
         picoquic_set_log_level(quic, 1);
-
         picoquic_enable_sslkeylog(quic, 1);
-
         picoquic_set_key_log_file_from_env(quic);
         
         // Always accept enable multicast
@@ -512,7 +313,7 @@ int picoquic_multicast_server(int server_port, int sender_port, const char *serv
         struct sockaddr_storage group_ip;
         picoquic_store_text_addr(&group_ip, PICOQUIC_MULTICAST_GROUP_IP, PICOQUIC_MULTICAST_GROUP_PORT);
 
-        picoquic_create_multicast_channel(quic, &default_context.mc_channel, PICOQUIC_MULTICAST_MAX_CLIENTS, &group_ip, NULL, max_rate);
+        picoquic_create_multicast_channel(quic, &global_ctx.mc_channel, PICOQUIC_MULTICAST_MAX_CLIENTS, &group_ip, NULL, max_rate);
     }
 
     /* Wait for packets using the wait loop provided in the library.
@@ -526,15 +327,20 @@ int picoquic_multicast_server(int server_port, int sender_port, const char *serv
      */
     if (ret == 0)
     {
-        ret = picoquic_packet_loop(quic, server_port, 0, 0, 0, 0, NULL, NULL);
+        ret = picoquic_packet_loop(quic, server_port, 0, 0, 0, 0, multicast_server_loop_cb, &global_ctx);
     }
 
-    /* And finish. */
+    // And finish.
     printf("Server exit, ret = %d\n", ret);
 
-    /* Clean up */
-    if (quic != NULL)
-    {
+    // Stop sender loop and delete sender context
+    multicast_sender_ctx_t* sender_ctx = &global_ctx.sender_app_ctx;
+    if (global_ctx.sender_running && sender_ctx != NULL) {
+        multicast_server_delete_sender_context(sender_ctx);
+    }
+
+    // Clean up server context and global quic context
+    if (quic != NULL) {
         picoquic_free(quic);
     }
 

--- a/multicast_sample/picoquic_multicast.h
+++ b/multicast_sample/picoquic_multicast.h
@@ -57,39 +57,41 @@ extern "C"
 
 #define PICOQUIC_MULTICAST_SENDER_MAX_FILES 32
 
-typedef struct st_multicast_sender_datagram_ctx_t {
-    struct st_multicast_sender_datagram_ctx_t* next_datagram;
-    struct st_multicast_sender_datagram_ctx_t* previous_datagram;
-    size_t name_length;
-    size_t file_length;
-    size_t file_sent;
-    FILE* F;
-    uint64_t fragment_number;
-    unsigned int is_name_sent : 1;
-    unsigned int is_file_open : 1;
-    unsigned int is_datagram_finished : 1;
-} multicast_sender_datagram_ctx_t;
+typedef struct st_multicast_server_ctx_t multicast_server_ctx_t;
 
 typedef struct st_multicast_sender_ctx_t {
-    picoquic_quic_t* quic;
-    picoquic_multicast_channel_t *mc_channel;
-    char const* file_path;
-    multicast_sender_datagram_ctx_t* first_datagram;
-    multicast_sender_datagram_ctx_t* last_datagram;
-    int is_disconnected;
+    FILE* F;
+    size_t file_length;
+    size_t file_sent;
+    unsigned int file_was_opened : 1;
+    uint64_t current_fragment_number;
+    picoquic_network_thread_ctx_t* thread_ctx;
+    multicast_server_ctx_t* server_ctx;
 } multicast_sender_ctx_t;
 
-int picoquic_multicast_client(char const *server_name, int server_port, char const *default_dir, int max_rate);
+typedef struct st_multicast_server_ctx_t
+{
+    char const *served_filename;
+    picoquic_multicast_channel_t *mc_channel;
+    int nb_joined_clients;
+    int nb_active_clients;
+    multicast_sender_ctx_t sender_app_ctx;
+    int sender_running;
+    int client_threshold;
+    const char *server_cert; 
+    const char *server_key;
+    int sender_port;
+    picoquic_quic_t* quic;
+    int is_closing;
+} multicast_server_ctx_t;
 
-int picoquic_multicast_sender_start(int server_port, 
-    const char* server_cert, const char* server_key,
-    char const* file_path, 
-    picoquic_multicast_channel_t* channel, picoquic_network_thread_ctx_t** thread_ctx,
-    multicast_sender_ctx_t* sender_ctx);
-    
-void picoquic_multicast_sender_stop(picoquic_network_thread_ctx_t* thread_ctx, multicast_sender_ctx_t* sender_ctx);
+int picoquic_multicast_client(char const *server_name, int server_port, 
+    char const *default_dir, int max_rate);
 
-int picoquic_multicast_server(int server_port, int sender_port, const char *server_cert, const char *server_key, int max_rate, const char *served_file);
+int picoquic_multicast_sender_start(multicast_sender_ctx_t* sender_ctx);
+
+int picoquic_multicast_server(int server_port, int sender_port, const char *server_cert, 
+    const char *server_key, int max_rate, const char *served_file, int client_threshold);
 
 #ifdef __cplusplus
 }

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -338,6 +338,7 @@ typedef enum {
     picoquic_callback_multicast_join_attempted, /* (server event) Multicast client sent MC_STATUS(Joined) */
     picoquic_callback_multicast_join_confirmed, /* (server event) Multicast client sent MC_ACK for first time */
     picoquic_callback_multicast_left, /* (server event) Multicast client sent MC_STATUS(Declined Join) or MC_STATUS(Left) */
+    picoquic_callback_multicast_retired, /* (server event) Multicast client sent MC_STATUS(Retired) */
     picoquic_callback_multicast_stream_data, /* (client event) Stream frame has been received over multicast */
     picoquic_callback_multicast_datagram, /* (client event) Datagram frame has been received over multicast */
 } picoquic_call_back_event_t;
@@ -749,6 +750,15 @@ int picoquic_schedule_mc_announce_and_join(picoquic_cnx_t* cnx, picoquic_multica
 
 /* Send MC_STATE(Joined) to server */
 int picoquic_join_mc_channel(picoquic_cnx_t* cnx, picoquic_multicast_channel_id_t* ch_id);
+
+/* Queue MC_LEAVE and MC_RETIRE frame to sending it to all clients */
+int picoquic_schedule_mc_leave_and_retire(picoquic_multicast_channel_t* channel);
+
+/* Queue MC_LEAVE frame to sending it to a specific clients */
+int picoquic_schedule_mc_leave(picoquic_multicast_channel_t* channel, picoquic_cnx_t* cnx);
+
+/* Queue MC_RETIRE frame to sending it to a specific clients */
+int picoquic_schedule_mc_retire(picoquic_multicast_channel_t* channel, picoquic_cnx_t* cnx);
 
 /* Set the Address Discovery mode for the context */
 void picoquic_set_default_address_discovery_mode(picoquic_quic_t* quic, int mode);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1331,7 +1331,8 @@ typedef struct st_picoquic_multicast_channel_t {
     char hash_algorithm_name[7];
     uint64_t max_rate; // max rate in kibps for this channel
     uint64_t max_ack_delay;
-    int is_retired;
+    int is_retiring; // Retiring was requested (e.g. by application), but not all joined clients accepted retiration yet
+    int is_retired; // All clients left the channel and it can safely be deleted
 
     // points to cnx where this channel was added to, may not yet joined or already left/retired
     picoquic_mc_channel_in_cnx_t** used_in_cnx;
@@ -1451,6 +1452,8 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     int mc_leave_acked;
     int mc_retire_acked;
     int key_acked;                                              // At least one MC_KEY frame was acked
+    int mc_leave_scheduled;
+    int mc_retire_scheduled;
     uint64_t latest_key_sequence_acked;
     int first_mc_integrity_sent;                                // sent at least one mc_integrity frame (needed bc the first packet no is 0)
     uint64_t mc_integrity_latest_pn_sent;                       // latest *multicast* packet number for which an integrity hash was sent

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1187,6 +1187,47 @@ int picoquic_join_mc_channel(picoquic_cnx_t* cnx, picoquic_multicast_channel_id_
     return 0;
 }
 
+// Schedule MC_LEAVE and MC_RETIRE frames for sending to clients implicitly by setting flags in ch_in_cnx
+int picoquic_schedule_mc_leave_and_retire(picoquic_multicast_channel_t* channel) 
+{
+    for (int i = 0; i < channel->nb_used_in_cnx; i++) {
+        picoquic_mc_channel_in_cnx_t* ch = channel->used_in_cnx[i];
+        ch->mc_leave_scheduled = 1;
+        ch->mc_retire_scheduled = 1;
+    }
+    channel->is_retiring = 1;
+
+    return 0;
+}
+
+// Schedule MC_LEAVE frame for sending to clients implicitly by setting flag in ch_in_cnx
+int picoquic_schedule_mc_leave(picoquic_multicast_channel_t* channel, picoquic_cnx_t* cnx) 
+{
+    picoquic_mc_channel_in_cnx_t* found_channel_cnx = picoquic_find_multicast_channel_in_cnx(&channel->channel_id, cnx);
+    if (found_channel_cnx == NULL) {
+        return -1;
+    }
+    found_channel_cnx->mc_leave_scheduled = 1;
+
+    return 0;
+}
+
+// Schedule MC_RETIRE frame for sending to clients implicitly by setting flag in ch_in_cnx
+int picoquic_schedule_mc_retire(picoquic_multicast_channel_t* channel, picoquic_cnx_t* cnx) 
+{
+    picoquic_mc_channel_in_cnx_t* found_channel_cnx = picoquic_find_multicast_channel_in_cnx(&channel->channel_id, cnx);
+    if (found_channel_cnx == NULL) {
+        return -1;
+    }
+    found_channel_cnx->mc_retire_scheduled = 1;
+
+    if (!found_channel_cnx->channel->is_retiring) {
+        found_channel_cnx->channel->is_retiring = 1;
+    }
+
+    return 0;
+}
+
 void picoquic_set_default_address_discovery_mode(picoquic_quic_t* quic, int mode)
 {
     if (mode > 0 && mode <= 3) {

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -3157,8 +3157,7 @@ uint8_t * picoquic_prepare_multicast_integrity_frames(picoquic_cnx_t* cnx, picoq
  */
 uint8_t * picoquic_prepare_multicast_init_frames(picoquic_cnx_t* cnx, picoquic_path_t* path_x,
     uint8_t * bytes, uint8_t * bytes_max, 
-    int * more_data, int* is_pure_ack,
-    uint64_t current_time, uint64_t * next_wake_time)
+    int * more_data, int* is_pure_ack)
 {
     if (cnx->mc_channels == NULL || cnx->nb_mc_channels == 0) {
         return bytes;
@@ -3198,6 +3197,51 @@ uint8_t * picoquic_prepare_multicast_init_frames(picoquic_cnx_t* cnx, picoquic_p
                 *is_pure_ack = 0;
                 bytes = bytes_next;
                 ch->state = picoquic_mc_state_join_pending;
+            }
+        }
+    }
+
+    return bytes;
+}
+
+/*
+ * Prepare leave/retire multicast frames from server to client (MC_LEAVE, MC_RETIRE)
+ */
+uint8_t * picoquic_prepare_multicast_leave_retire_frames(picoquic_cnx_t* cnx,
+    uint8_t * bytes, uint8_t * bytes_max, 
+    int * more_data, int* is_pure_ack)
+{
+    if (cnx->mc_channels == NULL || cnx->nb_mc_channels == 0 || cnx->nb_mc_channels == 0) {
+        return bytes;
+    }
+
+    for (int i = 0; i < cnx->nb_mc_channels; i++) {
+        picoquic_mc_channel_in_cnx_t* ch = cnx->mc_channels[i];
+
+        // CHECK MC: Currently, we always send both MC_LEAVE and MC_RETIRE frames, even if it would be enough
+        // to send MC_RETIRE when mc_retire_scheduled is set. This is just to showcase the functionality of both frames
+        // but can be simplified later to improve performance.
+
+        if (ch->state < picoquic_mc_state_retire_pending) {
+            // if channel leave or retire scheduled
+            if (ch->state < picoquic_mc_state_leave_pending && (ch->mc_leave_scheduled || ch->mc_retire_scheduled)) {
+                // TODO MC: Implement MC_LEAVE frame
+                // uint8_t *bytes_next = picoquic_format_mc_leave_frame(bytes, bytes_max, ch->channel, more_data);
+                // if (bytes_next > bytes) {
+                //     *is_pure_ack = 0;
+                //     bytes = bytes_next;
+                //     ch->state = picoquic_mc_state_leave_pending; 
+                // }
+            }
+            // if channel retire scheduled
+            if (ch->mc_retire_scheduled) {
+                // TODO MC: Implement MC_RETIRE frame
+                // uint8_t *bytes_next = picoquic_format_mc_retire_frame(bytes, bytes_max, ch->channel, more_data);
+                // if (bytes_next > bytes) {
+                //     *is_pure_ack = 0;
+                //     bytes = bytes_next;
+                //     ch->state = picoquic_mc_state_retire_pending; 
+                // }
             }
         }
     }
@@ -4192,8 +4236,7 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
                     if (cnx->is_multicast_enabled && !cnx->client_mode) {
                         /* SERVER: If required, prepare multicast announce, key and join frames. */
                         bytes_next = picoquic_prepare_multicast_init_frames(cnx, path_x,
-                        bytes_next, bytes_max, &more_data, &is_pure_ack,
-                        current_time, next_wake_time);
+                        bytes_next, bytes_max, &more_data, &is_pure_ack);
 
                         bytes_next = picoquic_prepare_multicast_integrity_frames(cnx, path_x,
                         bytes_next, bytes_max, &more_data, &is_pure_ack,
@@ -4221,6 +4264,12 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
                         if (ret == 0) {
                             bytes_next = picoquic_prepare_stream_and_datagrams(cnx, path_x, bytes_next, bytes_max,
                                 UINT64_MAX, current_time, &more_data, &is_pure_ack, &no_data_to_send, &ret);
+                        }
+
+                        if (cnx->is_multicast_enabled && !cnx->client_mode) {
+                            /* SERVER: Send MC_LEAVE and MC_RETIRE frames to client if required. */
+                            bytes_next = picoquic_prepare_multicast_leave_retire_frames(cnx,
+                            bytes_next, bytes_max, &more_data, &is_pure_ack);
                         }
 
                         /* TODO: replace this by scheduling of BDP frame when window has been estimated */


### PR DESCRIPTION
Clean up and extend application code:
- Clean up code in server/sender application
- Clean up code in client application
- Add configurable threshold to only start the sender when at least a specified amount of clients have joined
- Streamline sender thread handling and lifecycle management of the thread, including handling of multicast channel leave and retire

Additionally:
- Prepare some picoquic methods for handling `MC_LEAVE` and `MC_RETIRE` frames
- Add `/usr/include/mcrx` to search paths for `libmcrx` library