### PR TITLE
Multicast/`MC_LEAVE`, wake management and fix `MC_INTEGRITY` skip

### DIFF
--- a/loglib/logconvert.c
+++ b/loglib/logconvert.c
@@ -137,6 +137,10 @@ const char * ftype2str(picoquic_frame_type_enum_t ftype)
         return "mc_key";
     case picoquic_frame_type_mc_join:
         return "mc_join";
+    case picoquic_frame_type_mc_leave:
+        return "mc_leave";
+    case picoquic_frame_type_mc_retire:
+        return "mc_retire";
     case picoquic_frame_type_mc_state_multicast:
         return "mc_state_multicast";
     case picoquic_frame_type_mc_state_application:

--- a/loglib/qlog.c
+++ b/loglib/qlog.c
@@ -1420,6 +1420,54 @@ void qlog_mc_join_frame(FILE* f, bytestream* s)
     fprintf(f, ", \"mc_key_sequence_number\": %"PRIu64"", key_seq_num);
 }
 
+void qlog_mc_leave_frame(FILE* f, bytestream* s)
+{
+    uint64_t channel_id_length = 0;
+    byteread_vint(s, &channel_id_length);
+    fprintf(f, ", \"channel_id_length\": %"PRIu64"", channel_id_length);
+
+    fprintf(f, ", \"channel_id\": \"");
+    for (uint64_t i = 0; i < channel_id_length; i++) {
+        uint8_t byte = 0;
+        byteread_int8(s, &byte);
+        if (i == 0) {
+            fprintf(f, "%02X", byte);
+        } else {
+            fprintf(f, " %02X", byte);
+        }
+    }
+
+    uint64_t state_seq_num = 0;
+    byteread_vint(s, &state_seq_num);
+    fprintf(f, "\", \"mc_state_sequence_number\": %"PRIu64"", state_seq_num);
+
+    uint64_t after_packet_number = 0;
+    byteread_vint(s, &after_packet_number);
+    fprintf(f, ", \"after_packet_number\": %"PRIu64"", after_packet_number);
+}
+
+void qlog_mc_retire_frame(FILE* f, bytestream* s)
+{
+    uint64_t channel_id_length = 0;
+    byteread_vint(s, &channel_id_length);
+    fprintf(f, ", \"channel_id_length\": %"PRIu64"", channel_id_length);
+
+    fprintf(f, ", \"channel_id\": \"");
+    for (uint64_t i = 0; i < channel_id_length; i++) {
+        uint8_t byte = 0;
+        byteread_int8(s, &byte);
+        if (i == 0) {
+            fprintf(f, "%02X", byte);
+        } else {
+            fprintf(f, " %02X", byte);
+        }
+    }
+
+    uint64_t after_packet_number = 0;
+    byteread_vint(s, &after_packet_number);
+    fprintf(f, ", \"after_packet_number\": %"PRIu64"", after_packet_number);
+}
+
 void qlog_mc_state_frame(FILE* f, bytestream* s)
 {
     uint64_t channel_id_length = 0;
@@ -1742,6 +1790,12 @@ int qlog_packet_frame(bytestream * s, void * ptr)
         break;
     case picoquic_frame_type_mc_join:
         qlog_mc_join_frame(f, s);
+        break;
+    case picoquic_frame_type_mc_leave:
+        qlog_mc_leave_frame(f, s);
+        break;
+    case picoquic_frame_type_mc_retire:
+        qlog_mc_retire_frame(f, s);
         break;
     case picoquic_frame_type_mc_state_multicast:
     case picoquic_frame_type_mc_state_application:

--- a/multicast_sample/multicast.c
+++ b/multicast_sample/multicast.c
@@ -80,7 +80,7 @@ int main(int argc, char** argv)
         else {
             int server_port = get_port(argv[0], argv[3]);
             int max_rate = atoi(argv[5]);
-            exit_code = picoquic_multicast_client(argv[2], server_port, argv[4], max_rate);
+            exit_code = multicast_client(argv[2], server_port, argv[4], max_rate);
         }
     }
     else if (strcmp(argv[1], "server") == 0) {
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
                 client_threshold = atoi(argv[8]);
             }
 
-            exit_code = picoquic_multicast_server(server_port, sender_port, argv[4], argv[5], max_rate, argv[7], client_threshold);
+            exit_code = multicast_server(server_port, sender_port, argv[4], argv[5], max_rate, argv[7], client_threshold);
         }
     }
     else

--- a/multicast_sample/multicast_client.c
+++ b/multicast_sample/multicast_client.c
@@ -206,10 +206,12 @@ int multicast_client_callback(picoquic_cnx_t *cnx,
             break;
         case picoquic_callback_stateless_reset:
             fprintf(stdout, "app: Received a stateless reset.\n");
-            break;
         case picoquic_callback_close:
             fprintf(stdout, "app: Received request to close connection\n");
-            break;
+        case picoquic_callback_multicast_left:
+            fprintf(stdout, "app: Left the multicast channel, stop receiving\n");
+        case picoquic_callback_multicast_retired:
+            fprintf(stdout, "app: Retired the multicast client, stop receiving\n");
         case picoquic_callback_application_close:
             fprintf(stdout, "app: Received request to close application.\n");
             /* Remove the application callback */

--- a/multicast_sample/multicast_client.c
+++ b/multicast_sample/multicast_client.c
@@ -351,7 +351,6 @@ static int multicast_client_init(char const *server_name, int server_port, char 
             picoquic_set_key_log_file_from_env(*quic);
             picoquic_set_qlog(*quic, qlog_dir);
             picoquic_set_log_level(*quic, 1);
-            picoquic_enable_path_callbacks_default(*quic, 1);
 
             // Multicast settings
             client_ctx->tp_params = malloc(sizeof(picoquic_tp_multicast_client_params_t));

--- a/multicast_sample/multicast_client.c
+++ b/multicast_sample/multicast_client.c
@@ -421,7 +421,7 @@ static int multicast_client_init(char const *server_name, int server_port, char 
  *       if there is, send it.
  * - The loop breaks if the client connection is finished.
  */
-int picoquic_multicast_client(char const *server_name, int server_port, char const *default_dir, int max_rate)
+int multicast_client(char const *server_name, int server_port, char const *default_dir, int max_rate)
 {
     int ret = 0;
     struct sockaddr_storage server_address;

--- a/multicast_sample/multicast_sender.c
+++ b/multicast_sample/multicast_sender.c
@@ -92,7 +92,7 @@ int multicast_sender_open_file(multicast_sender_ctx_t* sender_ctx)
 }
 
 /* Schedule MC_LEAVE and MC_RETIRE frame to all clients (if not already done) to retire the channel */
-void picoquic_multicast_sender_retire(multicast_sender_ctx_t* sender_ctx) {
+void multicast_sender_retire(multicast_sender_ctx_t* sender_ctx) {
     picoquic_schedule_mc_leave_and_retire(sender_ctx->server_ctx->mc_channel);
 }
 
@@ -134,7 +134,7 @@ int multicast_sender_callback(picoquic_multicast_channel_t* channel,
             // thread at this point and notify server via callback
             if (sender_ctx->file_sent >= sender_ctx->file_length && sender_ctx->file_was_opened) {
                 picoquic_mark_datagram_ready_multicast(sender_ctx->server_ctx->mc_channel, 0);
-                picoquic_multicast_sender_retire(sender_ctx);
+                multicast_sender_retire(sender_ctx);
                 break;
             }
 
@@ -213,7 +213,7 @@ int multicast_sender_callback(picoquic_multicast_channel_t* channel,
                 // File sending finished, stop sender loop and delete 
                 // thread at this point and notify server via callback
                 if (!more_data) {
-                    picoquic_multicast_sender_retire(sender_ctx);
+                    multicast_sender_retire(sender_ctx);
                 }
             }
             break;
@@ -244,7 +244,7 @@ static int multicast_sender_init(multicast_sender_ctx_t *sender_ctx,
 }
 
 /* Start multicast sender server */
-int picoquic_multicast_sender_start(multicast_sender_ctx_t* sender_ctx) {
+int multicast_sender_start(multicast_sender_ctx_t* sender_ctx) {
     int ret = 0;
     int thread_ret = 0;
     picoquic_packet_loop_param_t param = { 0 };
@@ -259,9 +259,6 @@ int picoquic_multicast_sender_start(multicast_sender_ctx_t* sender_ctx) {
 
     // CHECK MC: GSO deactivated currently due to issues with local interfaces, may be re-activated later?
     param.do_not_use_gso = 1;
-
-    /* Set the callback context */
-    picoquic_set_callback_multicast(server_ctx->mc_channel, multicast_sender_callback, sender_ctx);
 
     /* Start the background thread. */
     sender_ctx->thread_ctx = picoquic_start_custom_network_thread_ex(server_ctx->quic, &param,

--- a/multicast_sample/multicast_sender.c
+++ b/multicast_sample/multicast_sender.c
@@ -91,12 +91,12 @@ int multicast_sender_open_file(multicast_sender_ctx_t* sender_ctx)
     return ret;
 }
 
-/* Schedule MC_LEAVE and MC_RETIRE frame to all clients to retire the channel */
+/* Schedule MC_LEAVE and MC_RETIRE frame to all clients (if not already done) to retire the channel */
 void picoquic_multicast_sender_retire(multicast_sender_ctx_t* sender_ctx) {
-    fprintf(stdout, "Nothing more to send, close channel with MC_LEAVE and MC_RETIRE\n");
     picoquic_schedule_mc_leave_and_retire(sender_ctx->server_ctx->mc_channel);
 }
 
+/* Multicast application callback */
 int multicast_sender_callback(picoquic_multicast_channel_t* channel,
     uint64_t stream_id, uint8_t* bytes, size_t length,
     picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx)

--- a/multicast_sample/multicast_server.c
+++ b/multicast_sample/multicast_server.c
@@ -189,7 +189,7 @@ int multicast_server_callback(picoquic_cnx_t *cnx,
             // If data sending on multicast channel did not start yet, start now
             fprintf(stdout, "Callback picoquic_callback_multicast_join_attempted, joined clients: %i, threshold: %i\n", server_ctx->nb_joined_clients, server_ctx->client_threshold);
             if (!server_ctx->sender_running && server_ctx->nb_joined_clients >= server_ctx->client_threshold) {
-                int err = picoquic_multicast_sender_start(&server_ctx->sender_app_ctx);
+                int err = multicast_sender_start(&server_ctx->sender_app_ctx);
                 if (err == 0) {
                     server_ctx->sender_running = 1;
                     fprintf(stdout, "Multicast sender started\n");
@@ -268,7 +268,7 @@ static int multicast_server_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_
  * - The loop breaks if the socket return an error.
  */
 
-int picoquic_multicast_server(int server_port, int sender_port, const char *server_cert, const char *server_key, int max_rate, const char *served_file, int client_threshold)
+int multicast_server(int server_port, int sender_port, const char *server_cert, const char *server_key, int max_rate, const char *served_file, int client_threshold)
 {
     /* Start: start the QUIC process with cert and key files */
     int ret = 0;

--- a/multicast_sample/picoquic_multicast.h
+++ b/multicast_sample/picoquic_multicast.h
@@ -85,12 +85,12 @@ typedef struct st_multicast_server_ctx_t
     int is_closing;
 } multicast_server_ctx_t;
 
-int picoquic_multicast_client(char const *server_name, int server_port, 
+int multicast_client(char const *server_name, int server_port, 
     char const *default_dir, int max_rate);
 
-int picoquic_multicast_sender_start(multicast_sender_ctx_t* sender_ctx);
+int multicast_sender_start(multicast_sender_ctx_t* sender_ctx);
 
-int picoquic_multicast_server(int server_port, int sender_port, const char *server_cert, 
+int multicast_server(int server_port, int sender_port, const char *server_cert, 
     const char *server_key, int max_rate, const char *served_file, int client_threshold);
 
 #ifdef __cplusplus

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -7551,6 +7551,8 @@ const uint8_t* picoquic_decode_mc_state_frame(picoquic_cnx_t* cnx, const uint8_t
         return NULL;
     }
 
+    channel_found->latest_state_sequence_available = sequence_number;
+
     // ENHANCE MC: Maybe add more defined behavior for the different state types
 
     // MC_STATE(Joined)
@@ -7596,12 +7598,12 @@ const uint8_t* picoquic_decode_mc_state_frame(picoquic_cnx_t* cnx, const uint8_t
     if (state == picoquic_mc_state_frame_left) {
         if (channel_found->state >= 5 && channel_found->state < picoquic_mc_state_left) {
             // client leaves a non-retired channel after join request by server
-            fprintf(stdout, "Got MC_STATE(Leave) from client\n");
+            fprintf(stdout, "Got MC_STATE(Left) from client\n");
             channel_found->state = picoquic_mc_state_left; 
         }
         else {
             // ignoring MC_STATE frame 
-            fprintf(stdout, "Notice: MC_STATE(Leave) frame received in non-joined state, ignoring frame\n");
+            fprintf(stdout, "Notice: MC_STATE(Left) frame received in non-joined state, ignoring frame\n");
         }
     }
 
@@ -7745,6 +7747,24 @@ int picoquic_check_mc_state_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* byt
 /*
  * MC_INTEGRITY frame
 */
+
+void picoquic_verify_multicast_packet(picoquic_multicast_packet_t** packet, picoquic_mc_channel_in_cnx_t* channel, uint64_t current_time) {
+    picoquic_multicast_update_leave_retired_waiting(channel, current_time);
+
+    if ((*packet)->next != NULL) {
+        ((picoquic_multicast_packet_t*)(*packet)->next)->prev = (*packet)->prev;
+    } else {
+        channel->awaiting_integrity_check_last = (picoquic_multicast_packet_t*)(*packet)->prev;
+    }
+    if ((*packet)->prev != NULL) {
+        ((picoquic_multicast_packet_t*)(*packet)->prev)->next = (*packet)->next;
+    } else {
+        channel->awaiting_integrity_check_first = (picoquic_multicast_packet_t*)(*packet)->next;
+    }
+    free((*packet)->bytes);
+    free((*packet)->hash);
+    free((*packet));
+}
 
 uint8_t* picoquic_format_mc_integrity_frame(uint8_t* bytes, uint8_t* bytes_max, picoquic_mc_channel_in_cnx_t* ch_in_cnx, int * more_data) {
     uint8_t* bytes0 = bytes;
@@ -8015,24 +8035,12 @@ const uint8_t* picoquic_decode_mc_integrity_frame(picoquic_cnx_t* cnx, const uin
 
                 // Hash verified! Decode frames and forward it to application
                 fprintf(stdout, "Hash of packet number %lu VERIFIED!\n", packet->pn);
+                
                 picoquic_decode_frames_multicast(channel_found, packet->bytes, packet->length, 
                     NULL, packet->pn, current_time, 1
                 );
-
-                // Remove packet from awaiting_integrity_check list
-                if (packet->next != NULL) {
-                    ((picoquic_multicast_packet_t*)packet->next)->prev = packet->prev;
-                } else {
-                    channel_found->awaiting_integrity_check_last = (picoquic_multicast_packet_t*)packet->prev;
-                }
-                if (packet->prev != NULL) {
-                    ((picoquic_multicast_packet_t*)packet->prev)->next = packet->next;
-                } else {
-                    channel_found->awaiting_integrity_check_first = (picoquic_multicast_packet_t*)packet->next;
-                }
-                free(packet->bytes);
-                free(packet->hash);
-                free(packet);
+                
+                picoquic_verify_multicast_packet(&packet, channel_found, current_time);
             }
 
             integrity = ((picoquic_multicast_packet_integrity_t*)integrity->next);
@@ -8559,7 +8567,7 @@ uint8_t* picoquic_format_mc_leave_frame(uint8_t* bytes, uint8_t* bytes_max, pico
     // MC_STATE Sequence number
     // After Packet number
     if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, ch_in_cnx->latest_state_sequence_available)) == NULL
-        || (bytes = picoquic_frames_varint_encode(bytes, bytes_max, ch_in_cnx->channel->pkt_ctx.send_sequence)) == NULL) {
+        || (bytes = picoquic_frames_varint_encode(bytes, bytes_max, ch_in_cnx->channel->pkt_ctx.send_sequence - 1)) == NULL) {
         *more_data = 1;
         return bytes0;
     } 
@@ -8584,7 +8592,7 @@ const uint8_t* picoquic_skip_mc_leave_frame(const uint8_t* bytes, const uint8_t*
 }
 
 const uint8_t* picoquic_decode_mc_leave_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, 
-    const uint8_t* bytes_max) 
+    const uint8_t* bytes_max, uint64_t current_time) 
 {
     const uint8_t* bytes0 = bytes;
 
@@ -8626,19 +8634,29 @@ const uint8_t* picoquic_decode_mc_leave_frame(picoquic_cnx_t* cnx, const uint8_t
 
     // ENHANCE MC: Add more detailled behavior in case of wrong sequence numbers
     if (mc_state_sequence_number < channel_found->latest_state_sequence_available) {
-        fprintf(stderr, "Error: Received a MC_LEAVE frame with wrong MC_STATE sequence number\n");
+        fprintf(stderr, "Error: Received a MC_LEAVE frame with wrong MC_STATE sequence number: %lu, actual sequence: %lu\n", mc_state_sequence_number, channel_found->latest_state_sequence_available);
         return NULL;
     }
 
-    if (after_packet_number > channel_found->channel->pkt_ctx.send_sequence) {
-        fprintf(stderr, "Received a MC_LEAVE frame with future packet number, wait until it arrives\n");
+    uint64_t highest_verified = picoquic_multicast_get_latest_packet_number_verified(channel_found->channel);
+
+    if (highest_verified < UINT64_MAX) {
+        fprintf(stdout, "Highest pn verified before first loss: %lu\n", highest_verified);
+    } else {
+        fprintf(stdout, "Highest pn verified before first loss: NULL\n");
+    }
+
+    if (highest_verified < UINT64_MAX && after_packet_number > highest_verified) {
+        channel_found->leave_after_packet_number = after_packet_number;
+        channel_found->leave_received_at = current_time;
+        fprintf(stderr, "Received a MC_LEAVE frame with future packet number (%li), wait until it arrives\n", after_packet_number);
     }
 
     if (channel_found->state < picoquic_mc_state_leave_waiting) {
         channel_found->state = picoquic_mc_state_leave_waiting;
     }
 
-    picoquic_multicast_update_leave_retired_waiting(channel_found);
+    picoquic_multicast_update_leave_retired_waiting(channel_found, current_time);
 
     return bytes;
 }
@@ -8928,20 +8946,7 @@ int picoquic_decode_frames_multicast(picoquic_mc_channel_in_cnx_t* ch_in_cnx, co
                 fprintf(stdout, "Hash of packet number %lu VERIFIED (without caching)!\n", pn64);
                 integrity_verified = 1;
 
-                // Remove packet from awaiting_integrity_check list
-                if (packet->next != NULL) {
-                    ((picoquic_multicast_packet_t*)packet->next)->prev = packet->prev;
-                } else {
-                    ch_in_cnx->awaiting_integrity_check_last = (picoquic_multicast_packet_t*)packet->prev;
-                }
-                if (packet->prev != NULL) {
-                    ((picoquic_multicast_packet_t*)packet->prev)->next = packet->next;
-                } else {
-                    ch_in_cnx->awaiting_integrity_check_first = (picoquic_multicast_packet_t*)packet->next;
-                }
-                free(packet->bytes);
-                free(packet->hash);
-                free(packet);
+                picoquic_verify_multicast_packet(&packet, ch_in_cnx, current_time);
             }
 
             integrity = ((picoquic_multicast_packet_integrity_t*)integrity->next);
@@ -8965,7 +8970,7 @@ int picoquic_decode_frames_multicast(picoquic_mc_channel_in_cnx_t* ch_in_cnx, co
     ch_in_cnx->channel->latest_packet_number_received = pn64;
 
     // Handle leave/retire when the packet number is reached
-    picoquic_multicast_update_leave_retired_waiting(ch_in_cnx);
+    picoquic_multicast_update_leave_retired_waiting(ch_in_cnx, current_time);
 
     while (bytes != NULL && bytes < bytes_max) {
         uint8_t first_byte = bytes[0];
@@ -9434,7 +9439,7 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, picoquic_path_t * path_x, const 
                             break;
                         case picoquic_frame_type_mc_leave:
                             fprintf(stdout, "Got MC_LEAVE frame\n");
-                            bytes = picoquic_decode_mc_leave_frame(cnx, bytes, bytes_max);
+                            bytes = picoquic_decode_mc_leave_frame(cnx, bytes, bytes_max, current_time);
                             break;
                         default:
                             /* Not implemented yet! */

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -8482,7 +8482,7 @@ uint8_t* picoquic_format_mc_ack_frame(picoquic_mc_channel_in_cnx_t* channel, uin
         }
     }
 
-    if (bytes > after_stamp){ // TODO MC: Fix this: currently, bytes == after_stamp, which should not be the case
+    if (bytes > after_stamp){
         fprintf(stdout, "Send MC_ACK\n");
         
         if (is_opportunistic) {
@@ -9074,23 +9074,6 @@ int picoquic_decode_frames_multicast(picoquic_mc_channel_in_cnx_t* ch_in_cnx, co
                         // TODO MC: Support MC_KEY frame via multicast
                         // bytes = picoquic_decode_mc_key_frame(cnx, bytes, bytes_max); 
                         ack_needed = 1;
-
-                        // CLEAN MC: Refactor event/error logging to qlog
-                        // if (bytes != NULL) {
-                        //     picoquic_multicast_channel_t* channel = cnx->mc_channels[cnx->nb_mc_channels-1]->channel;
-
-                        //     picoquic_multicast_aead_secret_t* aead = channel->aead_secrets[channel->nb_aead_secrets-1];
-                        //     fprintf(stdout, "Got MC_KEY frame for channel id ");
-                        //     print_hex_bytes(channel->channel_id.id, channel->channel_id.id_len);
-
-                        //     fprintf(stdout, "\n -- Key Sequence number: %lu\n", aead->key_seq_number);
-                        //     fprintf(stdout, " -- From Packet number: %lu\n", aead->from_pkt_number);
-                        //     fprintf(stdout, " -- Secret length: %lu\n", aead->secret_len);
-                        // } 
-                        // if (bytes == NULL) {
-                        //     fprintf(stdout, "ERROR: bytes == NULL after decoding MC_KEY frame\n");
-                        // }
-                        
                         break;
                     default:
                         /* Not implemented yet! */
@@ -9462,16 +9445,6 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, picoquic_path_t * path_x, const 
                             bytes = picoquic_decode_mc_state_frame(cnx, bytes, bytes_max, frame_id64); 
                             ack_needed = 1;
 
-                            // CLEAN MC: Refactor event/error logging to qlog
-                            // if (bytes != NULL) {
-                            //     picoquic_multicast_channel_t* channel = cnx->mc_channels[cnx->nb_mc_channels-1]->channel;
-                            //     picoquic_mc_channel_in_cnx_t* ch_in_cnx = picoquic_find_multicast_channel_in_cnx(&channel->channel_id, cnx);
-
-                            //     fprintf(stdout, " -- Channel id ");
-                            //     print_hex_bytes(channel->channel_id.id, channel->channel_id.id_len);
-                            //     fprintf(stdout, "\n -- State Seq number: %lu\n", ch_in_cnx->latest_state_sequence_available);
-                            //     fprintf(stdout, " -- New state (picoquic-internal-code): %u\n", ch_in_cnx->state);
-                            // } 
                             if (bytes == NULL) {
                                 fprintf(stdout, "ERROR: bytes == NULL after decoding MC_STATE frame\n");
                             }

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -63,7 +63,11 @@ int picoquic_check_mc_key_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes
     const uint8_t* bytes_max, int* no_need_to_repeat);
 int picoquic_process_ack_of_mc_join_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
     size_t bytes_size, size_t* consumed);
+int picoquic_process_ack_of_mc_leave_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
+    size_t bytes_size, size_t* consumed);
 int picoquic_check_mc_join_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes, 
+    const uint8_t* bytes_max, int* no_need_to_repeat);
+int picoquic_check_mc_leave_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes,
     const uint8_t* bytes_max, int* no_need_to_repeat);
 int picoquic_process_ack_of_mc_state_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
     size_t bytes_size, uint64_t ftype, size_t* consumed);
@@ -3652,6 +3656,9 @@ int picoquic_check_frame_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes,
                 case picoquic_frame_type_mc_join:
                     ret = picoquic_check_mc_join_needs_repeat(cnx, bytes, p_bytes_max, no_need_to_repeat);
                     break;
+                case picoquic_frame_type_mc_leave:
+                    ret = picoquic_check_mc_leave_needs_repeat(cnx, bytes, p_bytes_max, no_need_to_repeat);
+                    break;
                 case picoquic_frame_type_mc_state_multicast:
                 case picoquic_frame_type_mc_state_application:
                     ret = picoquic_check_mc_state_needs_repeat(cnx, bytes, p_bytes_max, no_need_to_repeat);
@@ -3826,6 +3833,10 @@ void picoquic_process_ack_of_frames(picoquic_cnx_t* cnx, picoquic_packet_t* p,
             break;
         case picoquic_frame_type_mc_join:
             ret = picoquic_process_ack_of_mc_join_frame(cnx, &p->bytes[byte_index], p->length - byte_index, &frame_length);
+            byte_index += frame_length;
+            break;
+        case picoquic_frame_type_mc_leave:
+            ret = picoquic_process_ack_of_mc_leave_frame(cnx, &p->bytes[byte_index], p->length - byte_index, &frame_length);
             byte_index += frame_length;
             break;
         case picoquic_frame_type_mc_state_multicast:
@@ -7046,9 +7057,13 @@ const uint8_t* picoquic_decode_mc_key_frame(picoquic_cnx_t* cnx, const uint8_t* 
     }
 
     // Validate key properties
-    if (channel_found != NULL && channel_found->key_available == 1 && channel_found->channel->nb_aead_secrets > 0 && 
-        (channel_found->latest_key_sequence_available + 1 != aead->key_seq_number
-        || channel_found->channel->aead_secrets[channel_found->channel->nb_aead_secrets]->from_pkt_number > aead->from_pkt_number)) 
+    if (channel_found->latest_key_sequence_available + 1 != aead->key_seq_number || 
+        (
+            channel_found != NULL && channel_found->latest_key_sequence_available != 0 && 
+            channel_found->channel->nb_aead_secrets > 0 && 
+            channel_found->channel->aead_secrets[channel_found->channel->nb_aead_secrets]->from_pkt_number > aead->from_pkt_number
+        )
+    )
     {
         fprintf(stderr, "Error: Received a MC_KEY with invalid properties\n");
         return NULL;
@@ -7097,7 +7112,6 @@ const uint8_t* picoquic_decode_mc_key_frame(picoquic_cnx_t* cnx, const uint8_t* 
         }
     }
 
-    new_channel_in_cnx->key_available = 1;
     new_channel_in_cnx->latest_key_sequence_available = aead->key_seq_number;
 
     return bytes;
@@ -7274,7 +7288,7 @@ uint8_t* picoquic_format_mc_join_frame(uint8_t* bytes, uint8_t* bytes_max, picoq
     picoquic_mc_channel_in_cnx_t* channel_found = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx);
 
     // TODO MC: Move this semantic checks to higher level methods and just stupidly try to parse the frame here?
-    if (channel_found == NULL || channel_found->key_available == 0 || channel_found->state < picoquic_mc_state_announced || channel_found->state >= picoquic_mc_state_retire_pending) {
+    if (channel_found == NULL || channel_found->latest_key_sequence_available == 0 || channel_found->state < picoquic_mc_state_announced || channel_found->state >= picoquic_mc_state_retire_pending) {
         fprintf(stderr, "Error: Received a MC_JOIN, but no MC_KEY and/or MC_ANNOUNCE was receved, or channel is already retired\n");
         return picoquic_skip_mc_join_frame(bytes0, bytes_max);
     }
@@ -7436,11 +7450,7 @@ uint8_t* picoquic_format_mc_state_frame(uint8_t* bytes, uint8_t* bytes_max, pico
         bytes += bytes_copied;
     }
 
-    if (ch_in_cnx->state_frame_available > 0) {
-        ch_in_cnx->latest_state_sequence_available++;
-    } else {
-        ch_in_cnx->state_frame_available = 1;
-    }
+    ch_in_cnx->latest_state_sequence_available++;
 
     // State seq number
     // State
@@ -7451,6 +7461,15 @@ uint8_t* picoquic_format_mc_state_frame(uint8_t* bytes, uint8_t* bytes_max, pico
         (bytes = picoquic_frames_varint_encode(bytes, bytes_max, reason)) != NULL
     ) {
         bytes = picoquic_frames_varint_encode(bytes, bytes_max, 0); // Reason phrase currently always empty
+    }
+
+    if (ch_in_cnx->cnx->callback_fn != NULL) {
+        if (state == picoquic_mc_state_frame_left) {
+            ch_in_cnx->cnx->callback_fn(ch_in_cnx->cnx, 0, NULL, 0, picoquic_callback_multicast_left, ch_in_cnx->cnx->callback_ctx, &ch_in_cnx->channel->channel_id);
+        }
+        if (state == picoquic_mc_state_frame_retired) {
+            ch_in_cnx->cnx->callback_fn(ch_in_cnx->cnx, 0, NULL, 0, picoquic_callback_multicast_retired, ch_in_cnx->cnx->callback_ctx, &ch_in_cnx->channel->channel_id);
+        }
     }
 
     // CLEAN MC: Refactor event/error logging to qlog
@@ -7506,7 +7525,7 @@ const uint8_t* picoquic_decode_mc_state_frame(picoquic_cnx_t* cnx, const uint8_t
 
     picoquic_mc_channel_in_cnx_t* channel_found = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx);
     if (channel_found == NULL) {
-        fprintf(stderr, "Error: Received a MC_JOIN, but no mc channel was found in the connection\n");
+        fprintf(stderr, "Error: Received a MC_STATE, but no mc channel was found in the connection\n");
         return NULL;
     }
 
@@ -7527,9 +7546,7 @@ const uint8_t* picoquic_decode_mc_state_frame(picoquic_cnx_t* cnx, const uint8_t
         bytes = picoquic_frames_fixed_skip(bytes, bytes_max, reason_phrase_length); // Skip reason phrase, if available
     }
 
-    if ((channel_found->state_frame_available == 0 && sequence_number != channel_found->latest_state_sequence_available) ||
-        (channel_found->state_frame_available > 0 && sequence_number != channel_found->latest_key_sequence_available + 1)
-    ) {
+    if (sequence_number != channel_found->latest_state_sequence_available + 1) {
         fprintf(stderr, "Error: Received a MC_STATE frame with non-strictly-increasing sequence number\n");
         return NULL;
     }
@@ -8510,6 +8527,212 @@ const uint8_t* picoquic_decode_mc_ack_frame(picoquic_cnx_t* cnx, const uint8_t* 
     return picoquic_skip_mc_ack_frame(bytes0, bytes_max, ftype == picoquic_frame_type_ack_ecn);
 }
 
+/*
+ * MC_LEAVE frame
+ */
+
+uint8_t* picoquic_format_mc_leave_frame(uint8_t* bytes, uint8_t* bytes_max, picoquic_mc_channel_in_cnx_t* ch_in_cnx, int * more_data)
+{
+    // CHECK MC: This is currently only delivered via unicast, even if multicast delivery could be allowed according to spec.
+    // However, the MC_STATE Sequence number cannot be provided when sending MC_LEAVE via multicast (client-specific) 
+    // which makes it impossible to deliver this frame in its current specification via multicast.
+
+    uint8_t* bytes0 = bytes;
+    
+    // Frame type
+    // Channel ID Length
+    if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, picoquic_frame_type_mc_leave)) == NULL
+        || (bytes = picoquic_frames_uint8_encode(bytes, bytes_max, ch_in_cnx->channel->channel_id.id_len)) == NULL) {
+        *more_data = 1;
+        return bytes0;
+    } 
+
+    // Channel ID
+    uint8_t bytes_copied = picoquic_format_multicast_channel_id(bytes, bytes_max - bytes, &ch_in_cnx->channel->channel_id);
+    if (bytes_copied == 0) {
+        *more_data = 1;
+        return bytes0;
+    } else {
+        bytes += bytes_copied;
+    }
+
+    // MC_STATE Sequence number
+    // After Packet number
+    if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, ch_in_cnx->latest_state_sequence_available)) == NULL
+        || (bytes = picoquic_frames_varint_encode(bytes, bytes_max, ch_in_cnx->channel->pkt_ctx.send_sequence)) == NULL) {
+        *more_data = 1;
+        return bytes0;
+    } 
+
+    if (ch_in_cnx->state < picoquic_mc_state_leave_pending) {
+        ch_in_cnx->state = picoquic_mc_state_leave_pending;
+    }
+
+    return bytes;
+}
+
+const uint8_t* picoquic_skip_mc_leave_frame(const uint8_t* bytes, const uint8_t* bytes_max) {
+    uint8_t ch_id_length = 0;
+
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &ch_id_length)) != NULL && // channel id length
+        (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, (uint64_t)ch_id_length)) != NULL && // channel id
+        (bytes = picoquic_frames_varint_skip(bytes, bytes_max)) != NULL) { // mc_state sequence number
+            bytes = picoquic_frames_varint_skip(bytes, bytes_max); // after packet number
+        }
+
+    return bytes;
+}
+
+const uint8_t* picoquic_decode_mc_leave_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, 
+    const uint8_t* bytes_max) 
+{
+    const uint8_t* bytes0 = bytes;
+
+    if (!cnx->is_multicast_enabled || !cnx->client_mode) {
+        picoquic_connection_error_ex(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, picoquic_frame_type_mc_leave, "Received unexpected MC_LEAVE frame\n");
+        return NULL;
+    }
+
+    uint8_t id_len;
+    picoquic_multicast_channel_id_t channel_id;
+
+    // Channel ID Length
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &id_len)) == NULL) {
+        return NULL;
+    }
+
+    // Channel ID
+    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes, id_len, &channel_id);
+    if (bytes_copied == 0) {
+        return NULL;
+    } 
+
+    picoquic_mc_channel_in_cnx_t* channel_found = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx);
+    if (channel_found == NULL) {
+        fprintf(stderr, "Error: Received a MC_LEAVE, but no mc channel was found in the connection\n");
+        return picoquic_skip_mc_leave_frame(bytes0, bytes_max);
+    }
+
+    bytes += bytes_copied;
+
+    uint64_t mc_state_sequence_number;
+    uint64_t after_packet_number;
+
+    if ((bytes = picoquic_frames_varint_decode(bytes, bytes_max, &mc_state_sequence_number)) == NULL ||
+        (bytes = picoquic_frames_varint_decode(bytes, bytes_max, &after_packet_number)) == NULL
+    ) {
+        return NULL;
+    }
+
+    // ENHANCE MC: Add more detailled behavior in case of wrong sequence numbers
+    if (mc_state_sequence_number < channel_found->latest_state_sequence_available) {
+        fprintf(stderr, "Error: Received a MC_LEAVE frame with wrong MC_STATE sequence number\n");
+        return NULL;
+    }
+
+    if (after_packet_number > channel_found->channel->pkt_ctx.send_sequence) {
+        fprintf(stderr, "Received a MC_LEAVE frame with future packet number, wait until it arrives\n");
+    }
+
+    if (channel_found->state < picoquic_mc_state_leave_waiting) {
+        channel_found->state = picoquic_mc_state_leave_waiting;
+    }
+
+    picoquic_multicast_update_leave_retired_waiting(channel_found);
+
+    return bytes;
+}
+
+int picoquic_process_ack_of_mc_leave_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
+    size_t bytes_size, size_t* consumed)
+{
+    const uint8_t* bytes_first = bytes;
+    const uint8_t* bytes_max = bytes + bytes_size;
+
+    // Skip frame type
+    const uint8_t* bytes_after_ftype = bytes = picoquic_frames_varint_skip(bytes, bytes_max);
+
+    uint8_t id_len;
+    picoquic_multicast_channel_id_t channel_id;
+    uint64_t seq_number;
+
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &id_len)) == NULL) {
+        return -1;
+    }
+
+    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes, id_len, &channel_id);
+
+    if (bytes_copied == 0) {
+        return -1;
+    }
+
+    bytes += bytes_copied;
+    bytes = picoquic_frames_varint_decode(bytes, bytes_max, &seq_number);
+    
+    if (bytes == NULL) {
+        return -1;
+    }
+
+    int ret = 0;
+    const uint8_t* bytes_next = picoquic_skip_mc_leave_frame(bytes_after_ftype, bytes_max);
+
+    if (bytes_next == NULL) {
+        return -1;
+    }
+    else {
+        picoquic_mc_channel_in_cnx_t* ch_in_cnx = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx);
+        if (ch_in_cnx == NULL) {
+            return -1;
+        }
+        ch_in_cnx->mc_leave_acked = 1;
+        *consumed = bytes_next - bytes_first;
+    }
+    
+    fprintf(stdout, "ACK of MC_LEAVE successfully processed\n");
+    return ret;
+}
+
+int picoquic_check_mc_leave_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes, const uint8_t* bytes_max, int* no_need_to_repeat)
+{
+    int ret = 0;
+    const uint8_t* bytes_parsing = bytes;
+    uint8_t id_len;
+    picoquic_multicast_channel_id_t channel_id;
+    *no_need_to_repeat = 0;
+
+    if ((bytes_parsing = picoquic_frames_uint8_decode(bytes_parsing, bytes_max, &id_len)) == NULL) {
+        *no_need_to_repeat = 1;
+        return -1;
+    }
+
+    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes_parsing, id_len, &channel_id);
+
+    if (bytes_copied == 0) {
+        *no_need_to_repeat = 1;
+        return -1;
+    }
+
+    picoquic_mc_channel_in_cnx_t* ch_in_cnx;
+
+    if ((ch_in_cnx = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx)) == NULL) {
+        /* If the channel is not in the connection (anymore?), no need to repeat this frame. */
+        *no_need_to_repeat = 1;
+    }
+    else if (ch_in_cnx->mc_leave_acked > 0) 
+    {
+        /* If MC_LEFT was acked, do not repeat */
+        *no_need_to_repeat = 1;
+    }
+
+    if (*no_need_to_repeat == 0) {
+        fprintf(stdout, "MC_LEAVE needs repeat\n");
+    } else {
+        fprintf(stdout, "MC_LEAVE do not need repeat\n");
+    }
+
+    return ret;
+}
+
 /* BDP frames as defined in https://tools.ietf.org/html/draft-kuhn-quic-0rtt-bdp-09
 */
 
@@ -8737,6 +8960,12 @@ int picoquic_decode_frames_multicast(picoquic_mc_channel_in_cnx_t* ch_in_cnx, co
         // Skip packet decoding for now
         return 0;
     }
+
+    // Store currently received packet number in channel
+    ch_in_cnx->channel->latest_packet_number_received = pn64;
+
+    // Handle leave/retire when the packet number is reached
+    picoquic_multicast_update_leave_retired_waiting(ch_in_cnx);
 
     while (bytes != NULL && bytes < bytes_max) {
         uint8_t first_byte = bytes[0];
@@ -9203,6 +9432,10 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, picoquic_path_t * path_x, const 
                             fprintf(stdout, "Got MC_ACK frame\n");
                             bytes = picoquic_decode_mc_ack_frame(cnx, bytes, bytes_max, frame_id64);
                             break;
+                        case picoquic_frame_type_mc_leave:
+                            fprintf(stdout, "Got MC_LEAVE frame\n");
+                            bytes = picoquic_decode_mc_leave_frame(cnx, bytes, bytes_max);
+                            break;
                         default:
                             /* Not implemented yet! */
                             picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, frame_id64);
@@ -9541,6 +9774,10 @@ int picoquic_skip_frame(const uint8_t* bytes, size_t bytes_maxsize, size_t* cons
                     break;
                 case picoquic_frame_type_mc_join:
                     bytes = picoquic_skip_mc_join_frame(bytes, bytes_max);
+                    *pure_ack = 0;
+                    break;
+                case picoquic_frame_type_mc_leave:
+                    bytes = picoquic_skip_mc_leave_frame(bytes, bytes_max);
                     *pure_ack = 0;
                     break;
                 case picoquic_frame_type_mc_state_multicast:

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -7991,7 +7991,7 @@ const uint8_t* picoquic_decode_mc_integrity_frame(picoquic_cnx_t* cnx, const uin
 
     // If no new hashes in frame, skip
     if (nb_hashes == nb_already_received) {
-        return picoquic_skip_mc_integrity_frame(bytes0, bytes_max, ftype);
+        return picoquic_skip_mc_integrity_frame(cnx, bytes0, bytes_max, ftype);
     }
 
     for (uint64_t number = pkt_nb_start; number <= pkt_nb_end; number++) {
@@ -8051,26 +8051,76 @@ const uint8_t* picoquic_decode_mc_integrity_frame(picoquic_cnx_t* cnx, const uin
     return bytes;
 }
 
-const uint8_t* picoquic_skip_mc_integrity_frame(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t ftype)
+const uint8_t* picoquic_skip_mc_integrity_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, const uint8_t* bytes_max, uint64_t ftype)
 {
     if (ftype != picoquic_frame_type_mc_integrity_l && ftype != picoquic_frame_type_mc_integrity) {
         return NULL; 
     }
 
     // picoquic_frame_type_mc_integrity indicates that frame is extended until packet bounds
-    if (picoquic_frame_type_mc_integrity) {
+    if (ftype == picoquic_frame_type_mc_integrity) {
         bytes = bytes_max;
         return bytes;
     }
 
     uint8_t ch_id_length = 0;
-    uint64_t hashes_length = 0;
+    size_t hash_length = 0;
+    uint64_t nb_hashes = 0;
+
+    picoquic_multicast_channel_id_t ch_id;
+
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &ch_id_length)) != NULL) // channel id length
+    {
+        uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes, ch_id_length, &ch_id);
+        if (bytes_copied == 0) {
+            return NULL;
+        } else {
+            bytes += bytes_copied;
+        }
+
+        picoquic_mc_channel_in_cnx_t* channel_found = picoquic_find_multicast_channel_in_cnx(&ch_id, cnx);
+        
+        if (channel_found == NULL) {
+            return NULL;
+        }
+
+        size_t hash_length = picoquic_hash_get_length(channel_found->channel->hash_algorithm_name);
+        if (hash_length == 0) {
+            return NULL;
+        }
+    }
+
+    if ((bytes = picoquic_frames_varint_skip(bytes, bytes_max)) != NULL && // packet number start
+        (bytes = picoquic_frames_varint_decode(bytes, bytes_max, &nb_hashes)) != NULL)  // hashes length
+    {
+        bytes = picoquic_frames_fixed_skip(bytes, bytes_max, nb_hashes * hash_length); // hashes
+    }
+
+    return bytes;
+}
+
+// CHECK MC: This method assumes a certain hash length. Only use when cnx is not accessible (e.g. logging)
+// CAUTION: Beware that this does only works as long as the hash length is equal to the assumed hash length!
+const uint8_t* picoquic_skip_mc_integrity_frame_assumed_hashlength(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t ftype, size_t hash_length)
+{
+    if (ftype != picoquic_frame_type_mc_integrity_l && ftype != picoquic_frame_type_mc_integrity) {
+        return NULL; 
+    }
+
+    // picoquic_frame_type_mc_integrity indicates that frame is extended until packet bounds
+    if (ftype == picoquic_frame_type_mc_integrity) {
+        bytes = bytes_max;
+        return bytes;
+    }
+
+    uint8_t ch_id_length = 0;
+    uint64_t nb_hashes = 0;
 
     if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &ch_id_length)) != NULL && // channel id length
         (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, (uint64_t)ch_id_length)) != NULL && // channel id
         (bytes = picoquic_frames_varint_skip(bytes, bytes_max)) != NULL && // packet number start
-        (bytes = picoquic_frames_varint_decode(bytes, bytes_max, &hashes_length)) != NULL) { // hashes length
-            bytes = picoquic_frames_fixed_skip(bytes, bytes_max, hashes_length); // hashes
+        (bytes = picoquic_frames_varint_decode(bytes, bytes_max, &nb_hashes)) != NULL) { // hashes length
+            bytes = picoquic_frames_fixed_skip(bytes, bytes_max, nb_hashes * hash_length); // hashes
         }
 
     return bytes;
@@ -8102,7 +8152,7 @@ int picoquic_process_ack_of_mc_integrity_frame(picoquic_cnx_t* cnx, const uint8_
     bytes = picoquic_frames_fixed_skip(bytes, bytes_max, bytes_copied);
     picoquic_frames_varint_decode(bytes, bytes_max, &packet_number_start);
 
-    const uint8_t* bytes_next = picoquic_skip_mc_integrity_frame(bytes_after_ftype, bytes_max, ftype);
+    const uint8_t* bytes_next = picoquic_skip_mc_integrity_frame(cnx, bytes_after_ftype, bytes_max, ftype);
 
     if (bytes_next == NULL) {
         return -1;
@@ -9792,7 +9842,8 @@ int picoquic_skip_frame(const uint8_t* bytes, size_t bytes_maxsize, size_t* cons
                     break;
                 case picoquic_frame_type_mc_integrity:
                 case picoquic_frame_type_mc_integrity_l:
-                    bytes = picoquic_skip_mc_integrity_frame(bytes, bytes_max, frame_id64);
+                    // CHECK MC: Assumed hash length, this is not valid when different hash lengths are possible
+                    bytes = picoquic_skip_mc_integrity_frame_assumed_hashlength(bytes, bytes_max, frame_id64, 48);
                     *pure_ack = 0;
                     break;
                 case picoquic_frame_type_mc_ack:

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -7563,7 +7563,7 @@ const uint8_t* picoquic_decode_mc_state_frame(picoquic_cnx_t* cnx, const uint8_t
             fprintf(stdout, "Got MC_STATE(Joined) from client\n");
             channel_found->state = picoquic_mc_state_join_attempted;
         }
-        else if (channel_found->state >= picoquic_mc_state_leave_pending && channel_found->state < picoquic_mc_state_retire_pending && channel_found->mc_join_acked) {
+        else if (channel_found->state >= picoquic_mc_state_left && channel_found->state < picoquic_mc_state_retire_pending && channel_found->mc_join_acked) {
             // Half-illegal behavior: Leave pending or left, but received MC_JOIN in the past
             fprintf(stdout, "Notice: Client joins multicast channel directly after trying to leave or left\n");
             channel_found->state = picoquic_mc_state_join_attempted;
@@ -7581,7 +7581,7 @@ const uint8_t* picoquic_decode_mc_state_frame(picoquic_cnx_t* cnx, const uint8_t
             fprintf(stdout, "Got MC_STATE(Declined Join) from client\n");
             channel_found->state = picoquic_mc_state_left; 
         }
-        else if (channel_found->state >= picoquic_mc_state_join_attempted && channel_found->state < picoquic_mc_state_leave_pending) {
+        else if (channel_found->state >= picoquic_mc_state_join_attempted && channel_found->state < picoquic_mc_state_left) {
             // Half-illegal behavior: Client already in Join attempted or join confirmed
             fprintf(stdout, "Notice: Client declined joining multicast channel after confirming join. Let client leave the channel.\n");
             channel_found->state = picoquic_mc_state_left; 
@@ -7974,7 +7974,7 @@ const uint8_t* picoquic_decode_mc_integrity_frame(picoquic_cnx_t* cnx, const uin
         return picoquic_skip_mc_integrity_frame(bytes0, bytes_max, ftype);
     }
 
-    for (int number = pkt_nb_start; number <= pkt_nb_end; number++) {
+    for (uint64_t number = pkt_nb_start; number <= pkt_nb_end; number++) {
         if (already_received[number - pkt_nb_start] == 1) {
             bytes += hash_length;
             continue;
@@ -8201,8 +8201,8 @@ int picoquic_check_mc_integrity_needs_repeat(picoquic_cnx_t* cnx, const uint8_t*
 
         nb_hashes = floor(length_hashes / hash_len);
 
-        if (ch_in_cnx->state >= picoquic_mc_state_leave_pending) {
-            // If the client left the channel or intends to leave it, do not repeat
+        if (ch_in_cnx->state >= picoquic_mc_state_left) {
+            // If the client left the channel, do not repeat
             *no_need_to_repeat = 1;
         } else {
             // Check if frame is in ch_in_cnx->integrity_frames_acked

--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -355,6 +355,12 @@ char const* textlog_frame_names(uint64_t frame_type)
     case picoquic_frame_type_mc_join:
         frame_name = "mc_join";
         break;
+    case picoquic_frame_type_mc_leave:
+        frame_name = "mc_leave";
+        break;
+    case picoquic_frame_type_mc_retire:
+        frame_name = "mc_retire";
+        break;
     case picoquic_frame_type_mc_state_multicast:
         frame_name = "mc_state_multicast";
         break;

--- a/picoquic/logwriter.c
+++ b/picoquic/logwriter.c
@@ -584,7 +584,10 @@ static const uint8_t* picoquic_log_mc_integrity_frame(FILE* f, const uint8_t* by
 {
     const uint8_t* bytes_begin = bytes;
     bytes = picoquic_log_varint_skip(bytes, bytes_max);
-    bytes = picoquic_skip_mc_integrity_frame(bytes, bytes_max, ftype);     
+    // ENHANCE MC: Warning: This method assumes as hash length of 48 (as in SHA384)
+    // This can change when another hash algorithm is used and is a workaround because we have
+    // no cnx context available here currently.
+    bytes = picoquic_skip_mc_integrity_frame_assumed_hashlength(bytes, bytes_max, ftype, 48);     
     picoquic_binlog_frame(f, bytes_begin, bytes);
 
     return bytes;

--- a/picoquic/logwriter.c
+++ b/picoquic/logwriter.c
@@ -560,6 +560,16 @@ static const uint8_t* picoquic_log_mc_join_frame(FILE* f, const uint8_t* bytes, 
     return bytes;
 }
 
+static const uint8_t* picoquic_log_mc_leave_frame(FILE* f, const uint8_t* bytes, const uint8_t* bytes_max)
+{
+    const uint8_t* bytes_begin = bytes;
+    bytes = picoquic_log_varint_skip(bytes, bytes_max);
+    bytes = picoquic_skip_mc_leave_frame(bytes, bytes_max);     
+    picoquic_binlog_frame(f, bytes_begin, bytes);
+
+    return bytes;
+}
+
 static const uint8_t* picoquic_log_mc_state_frame(FILE* f, const uint8_t* bytes, const uint8_t* bytes_max, uint64_t ftype)
 {
     const uint8_t* bytes_begin = bytes;
@@ -718,6 +728,9 @@ void picoquic_binlog_frames(FILE * f, const uint8_t* bytes, size_t length)
             break;
         case picoquic_frame_type_mc_join:
             bytes = picoquic_log_mc_join_frame(f, bytes, bytes_max);
+            break;
+        case picoquic_frame_type_mc_leave:
+            bytes = picoquic_log_mc_leave_frame(f, bytes, bytes_max);
             break;
         case picoquic_frame_type_mc_state_multicast:
         case picoquic_frame_type_mc_state_application:

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -2515,7 +2515,7 @@ int picoquic_incoming_1rtt_multicast(
     int ret = 0;
 
     /* Check the packet */
-    if (ch_in_cnx->state >= picoquic_mc_state_leave_pending || ch_in_cnx->state <= picoquic_mc_state_join_pending) {
+    if (ch_in_cnx->state >= picoquic_mc_state_left || ch_in_cnx->state <= picoquic_mc_state_join_pending) {
         /* Not yet joined or leaving/left or channel retired -> Just ignore the packet */
         ret = PICOQUIC_ERROR_UNEXPECTED_PACKET;
     }

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -3032,7 +3032,6 @@ int picoquic_incoming_segment(
         if (cnx != NULL && mc_ch_in_cnx == NULL && cnx->cnx_state != picoquic_state_disconnected &&
             ph.ptype != picoquic_packet_version_negotiation) {
             cnx->nb_packets_received++;
-            // TODO MC: Make sure that this is reached in multicast setting, to avoid idle timeout
             cnx->latest_receive_time = current_time;
             /* Mark the sequence number as received */
             ret = picoquic_record_pn_received(cnx, ph.pc, ph.l_cid, ph.pn64, receive_time);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -2310,7 +2310,7 @@ picoquic_mc_channel_in_cnx_t* picoquic_find_multicast_channel_in_cnx(picoquic_mu
     picoquic_cnx_t* cnx);
 picoquic_multicast_channel_t* picoquic_find_multicast_channel_global(picoquic_multicast_channel_id_t * ch_id, 
     picoquic_quic_t* quic);
-int picoquic_need_to_send_multicast_integrity(picoquic_quic_t* quic, 
+int picoquic_need_to_send_multicast_frames(picoquic_quic_t* quic, 
     uint64_t threshold, uint64_t current_time, int64_t* delta_t);
 void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_t* ch_in_cnx);
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -2338,8 +2338,10 @@ const uint8_t* picoquic_skip_mc_state_frame(const uint8_t* bytes,
     const uint8_t* bytes_max, uint64_t ftype);
 uint8_t* picoquic_format_mc_integrity_frame(uint8_t* bytes, 
     uint8_t* bytes_max, picoquic_mc_channel_in_cnx_t* ch_in_cnx, int * more_data);
-const uint8_t* picoquic_skip_mc_integrity_frame(const uint8_t* bytes, 
+const uint8_t* picoquic_skip_mc_integrity_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, 
     const uint8_t* bytes_max, uint64_t ftype);
+const uint8_t* picoquic_skip_mc_integrity_frame_assumed_hashlength(const uint8_t* bytes, 
+    const uint8_t* bytes_max, uint64_t ftype, size_t hash_length);
 const uint8_t* picoquic_skip_mc_ack_frame(const uint8_t* bytes, 
     const uint8_t* bytes_max, int is_ecn);
 uint8_t* picoquic_format_mc_leave_frame(uint8_t* bytes, uint8_t* bytes_max, 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1478,6 +1478,8 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     uint64_t latest_limits_sequence_acked;
     uint64_t leave_after_packet_number; // Send STATE(Left) after this packet number has been received
     uint64_t retire_after_packet_number; // Send STATE(Retired) after this packet number has been received
+    uint64_t leave_received_at;          // current_time when MC_LEAVE arrived (for timeout)
+    uint64_t retire_received_at;         // current_time when MC_RETIRE arrived (for timeout)
     uint64_t crypto_failure_count;
     picoquic_multicast_packet_t* awaiting_integrity_check_first;
     picoquic_multicast_packet_t* awaiting_integrity_check_last;
@@ -2313,7 +2315,8 @@ picoquic_multicast_channel_t* picoquic_find_multicast_channel_global(picoquic_mu
     picoquic_quic_t* quic);
 int picoquic_wake_for_multicast_frames(picoquic_quic_t* quic, 
     uint64_t threshold, uint64_t current_time, int64_t* delta_t);
-void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_t* ch_in_cnx);
+void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_t* ch_in_cnx, uint64_t current_time);
+uint64_t picoquic_multicast_get_latest_packet_number_verified(picoquic_multicast_channel_t* channel);
 
 picoquic_mc_channel_in_cnx_t* picoquic_add_channel_to_cnx(picoquic_cnx_t* cnx, 
     picoquic_multicast_channel_t* channel);
@@ -2341,6 +2344,8 @@ const uint8_t* picoquic_skip_mc_ack_frame(const uint8_t* bytes,
     const uint8_t* bytes_max, int is_ecn);
 uint8_t* picoquic_format_mc_leave_frame(uint8_t* bytes, uint8_t* bytes_max, 
     picoquic_mc_channel_in_cnx_t* ch_in_cnx, int * more_data);
+const uint8_t* picoquic_skip_mc_leave_frame(const uint8_t* bytes, 
+    const uint8_t* bytes_max);
 
 int picoquic_is_ack_needed_multicast(picoquic_cnx_t* cnx, uint64_t current_time, uint64_t* next_wake_time,
     int is_opportunistic);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1459,6 +1459,7 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     int key_acked;                                              // At least one MC_KEY frame was acked
     int mc_leave_scheduled;
     int mc_retire_scheduled;
+    uint64_t last_time_woken;                                        // When this cnx was last woken for sending multicast frames on unicast in the socket loop
     uint64_t latest_key_sequence_acked;
     int first_mc_integrity_sent;                                // sent at least one mc_integrity frame (needed bc the first packet no is 0)
     uint64_t mc_integrity_latest_pn_sent;                       // latest *multicast* packet number for which an integrity hash was sent
@@ -2310,7 +2311,7 @@ picoquic_mc_channel_in_cnx_t* picoquic_find_multicast_channel_in_cnx(picoquic_mu
     picoquic_cnx_t* cnx);
 picoquic_multicast_channel_t* picoquic_find_multicast_channel_global(picoquic_multicast_channel_id_t * ch_id, 
     picoquic_quic_t* quic);
-int picoquic_need_to_send_multicast_frames(picoquic_quic_t* quic, 
+int picoquic_wake_for_multicast_frames(picoquic_quic_t* quic, 
     uint64_t threshold, uint64_t current_time, int64_t* delta_t);
 void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_t* ch_in_cnx);
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1368,6 +1368,7 @@ typedef struct st_picoquic_multicast_channel_t {
     picoquic_multicast_packet_integrity_t* packet_integrity_last;
 
     /* Management of streams */
+    // CHECK MC: Currently no STREAM support in multicast
     picosplay_tree_t stream_tree;
     picoquic_stream_head_t * first_output_stream;
     picoquic_stream_head_t * last_output_stream;
@@ -1382,7 +1383,8 @@ typedef struct st_picoquic_multicast_channel_t {
 
     /* Management of datagram queue */
     unsigned int is_datagram_ready : 1; /* Active polling for datagrams */
-    picoquic_misc_frame_header_t* first_datagram; // CLEAN MC: Is first_datagram and last_datagram needed?
+    // ENHANCE MC: Add support for queuing multicast datagrams (currently only JIT API available)
+    picoquic_misc_frame_header_t* first_datagram;
     picoquic_misc_frame_header_t* last_datagram;
     uint64_t datagram_priority;
     int datagram_conflicts_count;
@@ -1448,7 +1450,6 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     struct mcrx_subscription* mcrx_subscription;
 
     // ack context
-    // TODO MC: Write to this context so that duplicate receive detection works
     picoquic_ack_context_t ack_ctx;
 
     // the following is used on server only:

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1362,6 +1362,7 @@ typedef struct st_picoquic_multicast_channel_t {
     picoquic_packet_context_t pkt_ctx; /* Packet context */
     unsigned int key_phase : 1; /* Key phase used in outgoing packets */
     unsigned int current_spin : 1;
+    uint64_t latest_packet_number_received; // Used on client only
 
     picoquic_multicast_packet_integrity_t* packet_integrity_first;
     picoquic_multicast_packet_integrity_t* packet_integrity_last;
@@ -1412,12 +1413,18 @@ typedef enum {
     // -> acknowledging first data on the multicast channel
     picoquic_mc_state_join_confirmed = 10,
 
+    // After receiving MC_LEAVE on client, but still receiving data until last packet has been received
+    picoquic_mc_state_leave_waiting = 13,
+
     // After sending/receiving MC_LEAVE
     picoquic_mc_state_leave_pending = 15,
 
     // After sending (client) or receiving (server) MC_STATE(Left)
     // OR MC_STATE(Declined Join)
     picoquic_mc_state_left = 20,
+
+    // After receiving MC_RETIRE on client, but still receiving data until last packet has been received
+    picoquic_mc_state_retire_waiting = 23,
 
     // After receiving (client) or sending (server) MC_RETIRE
     picoquic_mc_state_retire_pending = 25,
@@ -1434,9 +1441,7 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     picoquic_multicast_channel_t* channel;
     picoquic_cnx_t* cnx;
     picoquic_mc_state_enum state;
-    int key_available;
-    int state_frame_available;
-    int limits_frame_available;
+    // CHECK MC: Key sequence numbers are implicitly 0 before the first frame, and 1 when the first frame sent/arrived
     uint64_t latest_key_sequence_available;
     uint64_t latest_state_sequence_available;
     uint64_t latest_limits_sequence_available;
@@ -1470,6 +1475,8 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     int mc_limits_acked;                // At least one MC_LIMITS frame was acked
     uint64_t latest_state_sequence_acked;
     uint64_t latest_limits_sequence_acked;
+    uint64_t leave_after_packet_number; // Send STATE(Left) after this packet number has been received
+    uint64_t retire_after_packet_number; // Send STATE(Retired) after this packet number has been received
     uint64_t crypto_failure_count;
     picoquic_multicast_packet_t* awaiting_integrity_check_first;
     picoquic_multicast_packet_t* awaiting_integrity_check_last;
@@ -2305,6 +2312,7 @@ picoquic_multicast_channel_t* picoquic_find_multicast_channel_global(picoquic_mu
     picoquic_quic_t* quic);
 int picoquic_need_to_send_multicast_integrity(picoquic_quic_t* quic, 
     uint64_t threshold, uint64_t current_time, int64_t* delta_t);
+void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_t* ch_in_cnx);
 
 picoquic_mc_channel_in_cnx_t* picoquic_add_channel_to_cnx(picoquic_cnx_t* cnx, 
     picoquic_multicast_channel_t* channel);
@@ -2330,6 +2338,8 @@ const uint8_t* picoquic_skip_mc_integrity_frame(const uint8_t* bytes,
     const uint8_t* bytes_max, uint64_t ftype);
 const uint8_t* picoquic_skip_mc_ack_frame(const uint8_t* bytes, 
     const uint8_t* bytes_max, int is_ecn);
+uint8_t* picoquic_format_mc_leave_frame(uint8_t* bytes, uint8_t* bytes_max, 
+    picoquic_mc_channel_in_cnx_t* ch_in_cnx, int * more_data);
 
 int picoquic_is_ack_needed_multicast(picoquic_cnx_t* cnx, uint64_t current_time, uint64_t* next_wake_time,
     int is_opportunistic);

--- a/picoquic/picoquic_utils.h
+++ b/picoquic/picoquic_utils.h
@@ -86,11 +86,14 @@ char* picoquic_string_duplicate(const char* original);
 char* picoquic_string_free(char* str);
 int picoquic_sprintf(char* buf, size_t buf_len, size_t * nb_chars, const char* fmt, ...);
 
+typedef struct st_picoquic_multicast_packet_integrity_t picoquic_multicast_packet_integrity_t;
+
 extern const picoquic_connection_id_t picoquic_null_connection_id;
 uint8_t picoquic_format_connection_id(uint8_t* bytes, size_t bytes_max, picoquic_connection_id_t cnx_id);
 uint8_t picoquic_parse_connection_id(const uint8_t* bytes, uint8_t len, picoquic_connection_id_t *cnx_id);
 uint8_t picoquic_format_multicast_channel_id(uint8_t* bytes, size_t bytes_max, picoquic_multicast_channel_id_t* ch_id);
 uint8_t picoquic_parse_multicast_channel_id(const uint8_t * bytes, uint8_t len, picoquic_multicast_channel_id_t * ch_id);
+void picoquic_multicast_integrity_merge_sort(picoquic_multicast_packet_integrity_t** head_ref);
 int picoquic_is_connection_id_null(const picoquic_connection_id_t * cnx_id);
 int picoquic_compare_connection_id(const picoquic_connection_id_t * cnx_id1, const picoquic_connection_id_t * cnx_id2);
 uint64_t picoquic_connection_id_hash(const picoquic_connection_id_t * cid, const uint8_t * hash_seed);

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -935,14 +935,13 @@ picoquic_multicast_channel_t* picoquic_find_multicast_channel_global(picoquic_mu
 // `MC_INTEGRITY`/`MC_LEAVE`/`MC_RETIRE` or other multicast control frames to be sent via unicast
 // If yes, set delta_t lower for more frequent checking
 // If `MC_INTEGRITY` sending is at least some frames behind (defined by threshold), wake the cnx and set delta_t to zero
-int picoquic_need_to_send_multicast_frames(picoquic_quic_t* quic, uint64_t threshold, uint64_t current_time, int64_t* delta_t) {
+int picoquic_wake_for_multicast_frames(picoquic_quic_t* quic, uint64_t threshold, uint64_t current_time, int64_t* delta_t) {
     if (quic->nb_mc_channels == 0) {
         return 0;
     }
 
-    int64_t active_max_delta_t = 500000;
-
-    int active = 0;
+    int64_t active_max_delta_t = 300000;
+    int64_t wake_after_active = 100000;
 
     for (int i = 0; i < quic->nb_mc_channels; i++) {
         picoquic_multicast_channel_t* channel = quic->mc_channels[i];
@@ -955,13 +954,21 @@ int picoquic_need_to_send_multicast_frames(picoquic_quic_t* quic, uint64_t thres
             for (int j = 0; j < channel->nb_used_in_cnx; j++) {
                 picoquic_mc_channel_in_cnx_t* ch_in_cnx = channel->used_in_cnx[j];
                 if (ch_in_cnx->state < picoquic_mc_state_left) { // ENHANCE MC: Clarify when MC_INTEGRITY frames still need to be sent
+                    
                     // ENHANCE MC: Check if the receivers are really active (sent MC_ACK frames in the recent past)
                     // -> if not, make delay longer
+
+                    // Real Wake: Wake cnx if we really know that we need to send something (integrity, leave or retire frame)
                     if ((channel->packet_integrity_last != NULL && ch_in_cnx->mc_integrity_latest_pn_sent < channel->packet_integrity_last->packet_number)
-                        || ch_in_cnx->mc_leave_scheduled || ch_in_cnx->mc_retire_scheduled) {
-                            active = 1;
+                        || ch_in_cnx->mc_leave_scheduled) {
+                            ch_in_cnx->last_time_woken = current_time;
                             picoquic_reinsert_by_wake_time(quic, ch_in_cnx->cnx, current_time);
+                    // Threshold wake: Also wake a few more times if the last real wake was not too long ago, to make sure we really 
+                    // didn't miss anything before going into the long 10 seconds break of picoquic
+                    } else if (ch_in_cnx->last_time_woken + wake_after_active >= current_time) {
+                        picoquic_reinsert_by_wake_time(quic, ch_in_cnx->cnx, current_time);
                     }
+
                     if (channel->packet_integrity_last != NULL &&
                         ch_in_cnx->mc_integrity_latest_pn_sent + threshold < channel->packet_integrity_last->packet_number) {
                         *delta_t = 0;
@@ -971,10 +978,6 @@ int picoquic_need_to_send_multicast_frames(picoquic_quic_t* quic, uint64_t thres
                 }
             }
         }
-    }
-
-    if (active) {
-        return 1;
     }
 
     return 0;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -934,7 +934,7 @@ picoquic_multicast_channel_t* picoquic_find_multicast_channel_global(picoquic_mu
 // Find out if served channels have active joined multicast receivers that need 
 // `MC_INTEGRITY`/`MC_LEAVE`/`MC_RETIRE` or other multicast control frames to be sent via unicast
 // If yes, set delta_t lower for more frequent checking
-// If `MC_INTEGRITY` sending is at least some frames behind (defined by threshold), wake the cnx and set delta_t to zero
+// If `MC_INTEGRITY` sending is at most a few frames behind (defined by threshold), wake the cnx and set delta_t to zero
 int picoquic_wake_for_multicast_frames(picoquic_quic_t* quic, uint64_t threshold, uint64_t current_time, int64_t* delta_t) {
     if (quic->nb_mc_channels == 0) {
         return 0;
@@ -969,7 +969,7 @@ int picoquic_wake_for_multicast_frames(picoquic_quic_t* quic, uint64_t threshold
 
                     // Real Wake: Wake cnx if we really know that we need to send something (integrity, leave or retire frame)
                     if ((channel->packet_integrity_last != NULL && ch_in_cnx->mc_integrity_latest_pn_sent < channel->packet_integrity_last->packet_number)
-                        || ch_in_cnx->mc_leave_scheduled) {
+                        || ch_in_cnx->mc_leave_scheduled || ch_in_cnx->mc_retire_scheduled) {
                             ch_in_cnx->last_time_woken = current_time;
                             picoquic_reinsert_by_wake_time(quic, ch_in_cnx->cnx, current_time);
                     // Threshold wake: Also wake a few more times if the last real wake was not too long ago, to make sure we really 
@@ -1043,16 +1043,6 @@ int picoquic_create_multicast_channel(picoquic_quic_t* quic, picoquic_multicast_
     new_channel->max_ack_delay = PICOQUIC_ACK_DELAY_MAX;
     new_channel->quic = quic;
     new_channel->send_mtu = PICOQUIC_INITIAL_MTU_IPV4; // change when ipv6 is supported
-
-    // CLEAN MC: Remove if not needed
-    // if (new_channel->mc_tls_ctx == NULL) {
-    //     /* Only initialize TLS after all parameters have been set */
-    //     if (picoquic_tlscontext_create_mc(quic, new_channel, 0) != 0) {
-    //         // TODO MC: Delete channel
-    //         // picoquic_delete_mc_channel(new_channel);
-    //         // new_channel = NULL;
-    //     }
-    // }
 
     picoquic_compute_multicast_secrets(quic, new_channel);
 
@@ -1243,8 +1233,6 @@ void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_
     uint64_t highest_verified = picoquic_multicast_get_latest_packet_number_verified(ch_in_cnx->channel);
     uint64_t timeout = 3000000; // CHECK MC: Shortcut: If desired packet number is not arriving 3 seconds after MC_LEAVE, just leave
 
-    // TODO MC: Improve this check here so that not only the highest packet number verified is checked when leaving,
-    // but also, if all packets before were already received and verified (sometimes older packages arrive late)
     if (ch_in_cnx->state == picoquic_mc_state_retire_waiting && 
         ((highest_verified < UINT64_MAX && highest_verified >= ch_in_cnx->retire_after_packet_number) || ch_in_cnx->retire_received_at + timeout <= current_time)
     ) {

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1187,15 +1187,32 @@ int picoquic_join_mc_channel(picoquic_cnx_t* cnx, picoquic_multicast_channel_id_
     return 0;
 }
 
+// Schedule State(Left) / State(Retired) on client when in retire_waiting / leave_waiting states and final packet number has been received
+void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_t* ch_in_cnx) {
+    if (ch_in_cnx->channel->latest_packet_number_received >= ch_in_cnx->retire_after_packet_number && ch_in_cnx->state == picoquic_mc_state_retire_waiting) {
+        ch_in_cnx->state = picoquic_mc_state_retire_pending;
+        ch_in_cnx->state_scheduled = picoquic_mc_state_retired;
+        ch_in_cnx->state_frame_scheduled = picoquic_mc_state_frame_retired;
+        ch_in_cnx->state_reason_scheduled = picoquic_mc_state_reason_requested_by_server;
+    } 
+    else if (ch_in_cnx->channel->latest_packet_number_received >= ch_in_cnx->leave_after_packet_number && ch_in_cnx->state == picoquic_mc_state_leave_waiting) {
+        ch_in_cnx->state = picoquic_mc_state_leave_pending;
+        ch_in_cnx->state_scheduled = picoquic_mc_state_left;
+        ch_in_cnx->state_frame_scheduled = picoquic_mc_state_frame_left;
+        ch_in_cnx->state_reason_scheduled = picoquic_mc_state_reason_requested_by_server;
+    }
+}
+
 // Schedule MC_LEAVE and MC_RETIRE frames for sending to clients implicitly by setting flags in ch_in_cnx
 int picoquic_schedule_mc_leave_and_retire(picoquic_multicast_channel_t* channel) 
 {
     for (int i = 0; i < channel->nb_used_in_cnx; i++) {
         picoquic_mc_channel_in_cnx_t* ch = channel->used_in_cnx[i];
         ch->mc_leave_scheduled = 1;
-        ch->mc_retire_scheduled = 1;
+        // ch->mc_retire_scheduled = 1;
     }
     channel->is_retiring = 1;
+    fprintf(stdout, "MC_LEAVE (& MC_RETIRE) scheduled for %i clients\n", channel->nb_used_in_cnx);
 
     return 0;
 }

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -946,7 +946,7 @@ int picoquic_wake_for_multicast_frames(picoquic_quic_t* quic, uint64_t threshold
     for (int i = 0; i < quic->nb_mc_channels; i++) {
         picoquic_multicast_channel_t* channel = quic->mc_channels[i];
 
-        if (channel->client_mode || channel->is_retired) {
+        if (channel->is_retired) {
             continue;
         }
 
@@ -955,6 +955,15 @@ int picoquic_wake_for_multicast_frames(picoquic_quic_t* quic, uint64_t threshold
                 picoquic_mc_channel_in_cnx_t* ch_in_cnx = channel->used_in_cnx[j];
                 if (ch_in_cnx->state < picoquic_mc_state_left) { // ENHANCE MC: Clarify when MC_INTEGRITY frames still need to be sent
                     
+                    // In client mode, if in waiting state, wake more often, because client is waiting for timeout to leave channel
+                    if (channel->client_mode) {
+                        if (ch_in_cnx->state == picoquic_mc_state_leave_waiting || ch_in_cnx->state == picoquic_mc_state_retire_waiting) {
+                            picoquic_reinsert_by_wake_time(quic, ch_in_cnx->cnx, current_time);
+                            *delta_t = active_max_delta_t;
+                        }
+                        break;
+                    }
+
                     // ENHANCE MC: Check if the receivers are really active (sent MC_ACK frames in the recent past)
                     // -> if not, make delay longer
 
@@ -1199,15 +1208,54 @@ int picoquic_join_mc_channel(picoquic_cnx_t* cnx, picoquic_multicast_channel_id_
     return 0;
 }
 
+
+
+// Get highest packet number (strictly increasing without holes), for which a integrity hash is available
+uint64_t picoquic_multicast_get_latest_packet_number_verified(picoquic_multicast_channel_t* channel) {
+    if (channel->packet_integrity_first != NULL) {
+        picoquic_multicast_integrity_merge_sort(&channel->packet_integrity_first);
+        
+        picoquic_multicast_packet_integrity_t* current = channel->packet_integrity_first;
+        uint64_t last_pn = 0;
+        int first = 1;
+
+        while(current != NULL) {
+            if (((first && current->packet_number == last_pn) || (!first && current->packet_number == last_pn + 1))
+            ) {
+                first = 0;
+                last_pn = current->packet_number;
+                current = (picoquic_multicast_packet_integrity_t*)current->next;
+            } else {
+                break;
+            }
+        }
+
+        if (!first) {
+            return last_pn;
+        }
+    }
+
+    return UINT64_MAX;
+}
+
 // Schedule State(Left) / State(Retired) on client when in retire_waiting / leave_waiting states and final packet number has been received
-void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_t* ch_in_cnx) {
-    if (ch_in_cnx->channel->latest_packet_number_received >= ch_in_cnx->retire_after_packet_number && ch_in_cnx->state == picoquic_mc_state_retire_waiting) {
+void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_t* ch_in_cnx, uint64_t current_time) {
+    uint64_t highest_verified = picoquic_multicast_get_latest_packet_number_verified(ch_in_cnx->channel);
+    uint64_t timeout = 3000000; // CHECK MC: Shortcut: If desired packet number is not arriving 3 seconds after MC_LEAVE, just leave
+
+    // TODO MC: Improve this check here so that not only the highest packet number verified is checked when leaving,
+    // but also, if all packets before were already received and verified (sometimes older packages arrive late)
+    if (ch_in_cnx->state == picoquic_mc_state_retire_waiting && 
+        ((highest_verified < UINT64_MAX && highest_verified >= ch_in_cnx->retire_after_packet_number) || ch_in_cnx->retire_received_at + timeout <= current_time)
+    ) {
         ch_in_cnx->state = picoquic_mc_state_retire_pending;
         ch_in_cnx->state_scheduled = picoquic_mc_state_retired;
         ch_in_cnx->state_frame_scheduled = picoquic_mc_state_frame_retired;
         ch_in_cnx->state_reason_scheduled = picoquic_mc_state_reason_requested_by_server;
     } 
-    else if (ch_in_cnx->channel->latest_packet_number_received >= ch_in_cnx->leave_after_packet_number && ch_in_cnx->state == picoquic_mc_state_leave_waiting) {
+    else if (ch_in_cnx->state == picoquic_mc_state_leave_waiting && 
+        ((highest_verified < UINT64_MAX && highest_verified >= ch_in_cnx->leave_after_packet_number) || ch_in_cnx->leave_received_at + timeout <= current_time)
+    ) {
         ch_in_cnx->state = picoquic_mc_state_leave_pending;
         ch_in_cnx->state_scheduled = picoquic_mc_state_left;
         ch_in_cnx->state_frame_scheduled = picoquic_mc_state_frame_left;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -931,41 +931,50 @@ picoquic_multicast_channel_t* picoquic_find_multicast_channel_global(picoquic_mu
     return NULL;
 }
 
-// Find out if served channels have active joined multicast receivers that need `MC_INTEGRITY` frames
+// Find out if served channels have active joined multicast receivers that need 
+// `MC_INTEGRITY`/`MC_LEAVE`/`MC_RETIRE` or other multicast control frames to be sent via unicast
 // If yes, set delta_t lower for more frequent checking
 // If `MC_INTEGRITY` sending is at least some frames behind (defined by threshold), wake the cnx and set delta_t to zero
-int picoquic_need_to_send_multicast_integrity(picoquic_quic_t* quic, uint64_t threshold, uint64_t current_time, int64_t* delta_t) {
+int picoquic_need_to_send_multicast_frames(picoquic_quic_t* quic, uint64_t threshold, uint64_t current_time, int64_t* delta_t) {
     if (quic->nb_mc_channels == 0) {
         return 0;
     }
 
-    int64_t active_max_delta_t = 300000;
+    int64_t active_max_delta_t = 500000;
+
+    int active = 0;
 
     for (int i = 0; i < quic->nb_mc_channels; i++) {
         picoquic_multicast_channel_t* channel = quic->mc_channels[i];
 
-        if (channel->client_mode || channel->is_retired || channel->packet_integrity_last == NULL) {
+        if (channel->client_mode || channel->is_retired) {
             continue;
         }
 
         if (channel->nb_used_in_cnx > 0) {
             for (int j = 0; j < channel->nb_used_in_cnx; j++) {
                 picoquic_mc_channel_in_cnx_t* ch_in_cnx = channel->used_in_cnx[j];
-                if (ch_in_cnx->state < picoquic_mc_state_leave_pending) {
+                if (ch_in_cnx->state < picoquic_mc_state_left) { // ENHANCE MC: Clarify when MC_INTEGRITY frames still need to be sent
                     // ENHANCE MC: Check if the receivers are really active (sent MC_ACK frames in the recent past)
                     // -> if not, make delay longer
-                    if (ch_in_cnx->mc_integrity_latest_pn_sent + threshold <= channel->packet_integrity_last->packet_number) {
-                        picoquic_reinsert_by_wake_time(quic, ch_in_cnx->cnx, current_time);
-                        *delta_t = 0;
-                    } else {
-                        if (*delta_t > active_max_delta_t) {
-                            *delta_t = active_max_delta_t;
-                        }
+                    if ((channel->packet_integrity_last != NULL && ch_in_cnx->mc_integrity_latest_pn_sent < channel->packet_integrity_last->packet_number)
+                        || ch_in_cnx->mc_leave_scheduled || ch_in_cnx->mc_retire_scheduled) {
+                            active = 1;
+                            picoquic_reinsert_by_wake_time(quic, ch_in_cnx->cnx, current_time);
                     }
-                    return 1;
+                    if (channel->packet_integrity_last != NULL &&
+                        ch_in_cnx->mc_integrity_latest_pn_sent + threshold < channel->packet_integrity_last->packet_number) {
+                        *delta_t = 0;
+                    } else if (*delta_t > active_max_delta_t) {
+                        *delta_t = active_max_delta_t;
+                    }
                 }
             }
         }
+    }
+
+    if (active) {
+        return 1;
     }
 
     return 0;
@@ -1206,13 +1215,23 @@ void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_
 // Schedule MC_LEAVE and MC_RETIRE frames for sending to clients implicitly by setting flags in ch_in_cnx
 int picoquic_schedule_mc_leave_and_retire(picoquic_multicast_channel_t* channel) 
 {
+    int scheduled = 0;
     for (int i = 0; i < channel->nb_used_in_cnx; i++) {
         picoquic_mc_channel_in_cnx_t* ch = channel->used_in_cnx[i];
-        ch->mc_leave_scheduled = 1;
-        // ch->mc_retire_scheduled = 1;
+        if (ch->state < picoquic_mc_state_leave_pending && ch->mc_leave_scheduled == 0) {
+            ch->mc_leave_scheduled = 1;
+            scheduled = 1;
+        }
+        if (ch->state < picoquic_mc_state_retire_pending && ch->mc_retire_scheduled == 0) {
+            scheduled = 1;
+            ch->mc_retire_scheduled = 1;
+        }
     }
-    channel->is_retiring = 1;
-    fprintf(stdout, "MC_LEAVE (& MC_RETIRE) scheduled for %i clients\n", channel->nb_used_in_cnx);
+
+    if (scheduled) {
+        channel->is_retiring = 1;
+        fprintf(stdout, "MC_LEAVE (& MC_RETIRE) scheduled for %i clients\n", channel->nb_used_in_cnx);
+    }
 
     return 0;
 }

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -3133,10 +3133,9 @@ uint8_t * picoquic_prepare_multicast_integrity_frames(picoquic_cnx_t* cnx, picoq
     }
 
     for (int i = 0; i < cnx->nb_mc_channels; i++) {
-        // TODO MC: Send MC_INTEGRITY frames for joined clients
         picoquic_mc_channel_in_cnx_t* ch = cnx->mc_channels[i];
         if (ch->state >= picoquic_mc_state_join_attempted 
-            && ch->state < picoquic_mc_state_leave_pending
+            && ch->state < picoquic_mc_state_left // ENHANCE MC: Clarify when MC_INTEGRITY frames still need to be sent
             && ch->channel->packet_integrity_first != NULL
             && ch->channel->packet_integrity_last != NULL
             && (ch->first_mc_integrity_sent == 0 || ch->mc_integrity_latest_pn_sent < ch->channel->packet_integrity_last->packet_number)
@@ -5548,6 +5547,7 @@ int picoquic_prepare_next_packet_ex(picoquic_quic_t* quic,
         picoquic_cnx_t* cnx = picoquic_get_earliest_cnx_to_wake(quic, current_time);
 
         if (cnx == NULL) {
+            fprintf(stdout, "No connection found to wake now\n");
             *send_length = 0;
         }
         else {

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -3177,15 +3177,14 @@ uint8_t * picoquic_prepare_multicast_init_frames(picoquic_cnx_t* cnx, picoquic_p
         }
         
         // send MC_KEY of latest AEAD key if no key was sent on this cnx yet
-        if (ch->key_available < 1 && ch->latest_key_sequence_available == 0 && ch->channel->nb_aead_secrets > 0) {
-            int key_sequence_number = ch->channel->nb_aead_secrets - 1;
+        if (ch->latest_key_sequence_available == 0 && ch->channel->nb_aead_secrets > 0) {
+            int key_sequence_number = ch->channel->nb_aead_secrets;
             picoquic_multicast_aead_secret_t* aead = ch->channel->aead_secrets[ch->channel->nb_aead_secrets-1];
 
             uint8_t *bytes_next = picoquic_format_mc_key_frame(bytes, bytes_max, ch->channel, aead, more_data);
             if (bytes_next > bytes) {
                 *is_pure_ack = 0;
                 bytes = bytes_next;
-                ch->key_available = 1;
                 ch->latest_key_sequence_available = key_sequence_number;
             }
         }
@@ -3225,22 +3224,24 @@ uint8_t * picoquic_prepare_multicast_leave_retire_frames(picoquic_cnx_t* cnx,
         if (ch->state < picoquic_mc_state_retire_pending) {
             // if channel leave or retire scheduled
             if (ch->state < picoquic_mc_state_leave_pending && (ch->mc_leave_scheduled || ch->mc_retire_scheduled)) {
-                // TODO MC: Implement MC_LEAVE frame
-                // uint8_t *bytes_next = picoquic_format_mc_leave_frame(bytes, bytes_max, ch->channel, more_data);
-                // if (bytes_next > bytes) {
-                //     *is_pure_ack = 0;
-                //     bytes = bytes_next;
-                //     ch->state = picoquic_mc_state_leave_pending; 
-                // }
+                fprintf(stdout, "Prepare MC_LEAVE frame\n");
+                uint8_t *bytes_next = picoquic_format_mc_leave_frame(bytes, bytes_max, ch, more_data);
+                if (bytes_next > bytes) {
+                    *is_pure_ack = 0;
+                    bytes = bytes_next;
+                    ch->state = picoquic_mc_state_leave_pending; 
+                    ch->mc_leave_scheduled = 0;
+                }
             }
             // if channel retire scheduled
             if (ch->mc_retire_scheduled) {
                 // TODO MC: Implement MC_RETIRE frame
-                // uint8_t *bytes_next = picoquic_format_mc_retire_frame(bytes, bytes_max, ch->channel, more_data);
+                // uint8_t *bytes_next = picoquic_format_mc_retire_frame(bytes, bytes_max, ch, more_data);
                 // if (bytes_next > bytes) {
                 //     *is_pure_ack = 0;
                 //     bytes = bytes_next;
                 //     ch->state = picoquic_mc_state_retire_pending; 
+                //     ch->mc_retire_scheduled = 0;
                 // }
             }
         }
@@ -3292,7 +3293,7 @@ uint8_t * picoquic_prepare_multicast_state_frames(picoquic_cnx_t* cnx,
         picoquic_mc_channel_in_cnx_t* ch = cnx->mc_channels[i];
 
         // if in state "join pending" and MC_KEY received -> check if client can join
-        if (ch->state >= picoquic_mc_state_join_pending && ch->state < picoquic_mc_state_join_attempted && ch->key_available > 0) {
+        if (ch->state >= picoquic_mc_state_join_pending && ch->state < picoquic_mc_state_join_attempted && ch->latest_key_sequence_available > 0) {
             nb_channels_join_pending++;
             picoquic_tp_multicast_client_params_t* params = &cnx->local_parameters.multicast_client_params;
 

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -3291,6 +3291,9 @@ uint8_t * picoquic_prepare_multicast_state_frames(picoquic_cnx_t* cnx,
     for (int i = 0; i < cnx->nb_mc_channels; i++) {
         picoquic_mc_channel_in_cnx_t* ch = cnx->mc_channels[i];
 
+        // If waiting for leaving/retiring channel as client, see if timeout is reached
+        picoquic_multicast_update_leave_retired_waiting(ch, current_time);
+
         // if in state "join pending" and MC_KEY received -> check if client can join
         if (ch->state >= picoquic_mc_state_join_pending && ch->state < picoquic_mc_state_join_attempted && ch->latest_key_sequence_available > 0) {
             nb_channels_join_pending++;
@@ -3312,29 +3315,29 @@ uint8_t * picoquic_prepare_multicast_state_frames(picoquic_cnx_t* cnx,
                 // Callback to application to decide whether the join should happen or not
                 cnx->callback_fn(cnx, 0, NULL, 0, picoquic_callback_multicast_join_possible, cnx->callback_ctx, &ch->channel->channel_id);
             }
+        }
             
-            // Send scheduled state frame (e.g. desired by application)
-            if (ch->state_scheduled != 0 && ch->state_frame_scheduled != 0 && ch->state_scheduled != ch->state) {
-                picoquic_frame_type_enum_t ftype = picoquic_frame_type_mc_state_multicast;
-                if (ch->state_reason_scheduled > picoquic_mc_state_reason_limit_violation) {
-                    ftype = picoquic_frame_type_mc_state_application;
-                }
-                uint8_t *bytes_next = picoquic_format_mc_state_frame(bytes, bytes_max, ch, more_data,
-                    ftype,
-                    ch->state_frame_scheduled,
-                    ch->state_reason_scheduled);
+        // Send scheduled state frame (e.g. desired by application)
+        if (ch->state_scheduled != 0 && ch->state_frame_scheduled != 0 && ch->state_scheduled != ch->state) {
+            fprintf(stdout, "Format MC_STATE frame\n");
+            picoquic_frame_type_enum_t ftype = picoquic_frame_type_mc_state_multicast;
+            if (ch->state_reason_scheduled > picoquic_mc_state_reason_limit_violation) {
+                ftype = picoquic_frame_type_mc_state_application;
+            }
+            uint8_t *bytes_next = picoquic_format_mc_state_frame(bytes, bytes_max, ch, more_data,
+                ftype,
+                ch->state_frame_scheduled,
+                ch->state_reason_scheduled);
 
-                if (bytes_next > bytes) {
-                    *is_pure_ack = 0;
-                    bytes = bytes_next;
-                    ch->state = ch->state_scheduled; 
-                    ch->state_frame_scheduled = 0;
-                    ch->state_reason_scheduled = 0;
-                    ch->state_scheduled = 0;
-                }
+            if (bytes_next > bytes) {
+                *is_pure_ack = 0;
+                bytes = bytes_next;
+                ch->state = ch->state_scheduled; 
+                ch->state_frame_scheduled = 0;
+                ch->state_reason_scheduled = 0;
+                ch->state_scheduled = 0;
             }
         }
-        // TODO MC: Implement handling of other states -> sending appropriate MC_STATE frames
     }
 
     return bytes;

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -5547,7 +5547,6 @@ int picoquic_prepare_next_packet_ex(picoquic_quic_t* quic,
         picoquic_cnx_t* cnx = picoquic_get_earliest_cnx_to_wake(quic, current_time);
 
         if (cnx == NULL) {
-            fprintf(stdout, "No connection found to wake now\n");
             *send_length = 0;
         }
         else {

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -4511,8 +4511,6 @@ int picoquic_generate_packet_hash_multicast(picoquic_multicast_channel_t* channe
     
     // CLEAN MC: Remove debug output
     fprintf(stdout, "Generated %s hash for packet no %li\n", channel->hash_algorithm_name, pi_new->packet_number);
-    // print_hex_bytes(pi_new->hash, hash_length);
-    // fprintf(stdout, "\n");
 
     // Indicate that this element can now be used by concurrently running processes
     pi_new->is_active = 1;
@@ -5205,7 +5203,6 @@ int picoquic_prepare_packet_multicast(picoquic_multicast_channel_t* channel,
                     packet_size += segment_length;
                     if (packet->length == 0) {
                         /* Nothing more to send */
-                        // TODO MC: Fix occasionally occuring double frees with recycle_packet
                         picoquic_recycle_packet_multicast(channel, packet);
                     }
                     else if (segment_length == 0) {

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -756,7 +756,6 @@ static int monitor_system_call_duration(packet_loop_system_call_duration_t* sc_d
 /* 
  * Socket loop for multicast sender. No receiving, minimal logic, only sends data to multicast group address.
  * No support for Windows for now.
- * // TODO MC: Change this, so that it only sends data for specified multicast channel
  */
 void* picoquic_packet_loop_multicast_send(void* v_ctx)
 {

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -1120,12 +1120,7 @@ void* picoquic_packet_loop_v3(void* v_ctx)
                 }
             }
             // CHECK MC: Set delta lower on active multicast receivers, set to zero when MC_INTEGRITY frames have to be sent
-            int64_t multicast_delta_t;
-            if (picoquic_need_to_send_multicast_frames(quic, mc_integrity_packet_threshold, current_time, &multicast_delta_t)) {
-                if (multicast_delta_t < delta_t) {
-                    delta_t = multicast_delta_t;
-                }
-            }
+            picoquic_wake_for_multicast_frames(quic, mc_integrity_packet_threshold, current_time, &delta_t);
         }
         else {
             nb_loop_immediate++;

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -1121,7 +1121,7 @@ void* picoquic_packet_loop_v3(void* v_ctx)
             }
             // CHECK MC: Set delta lower on active multicast receivers, set to zero when MC_INTEGRITY frames have to be sent
             int64_t multicast_delta_t;
-            if (picoquic_need_to_send_multicast_integrity(quic, mc_integrity_packet_threshold, current_time, &multicast_delta_t)) {
+            if (picoquic_need_to_send_multicast_frames(quic, mc_integrity_packet_threshold, current_time, &multicast_delta_t)) {
                 if (multicast_delta_t < delta_t) {
                     delta_t = multicast_delta_t;
                 }

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1520,7 +1520,7 @@ int picoquic_compute_multicast_secrets(picoquic_quic_t * quic, picoquic_multicas
     picoquic_setup_multicast_crypto_context_header(quic, &channel->header_secret, &channel->crypto_context, channel->header_protection_algorithm, 1);
     picoquic_setup_multicast_crypto_context_aead(quic, new_aead_secret, &channel->crypto_context, channel->aead_algorithm, 1);
 
-    new_aead_secret->key_seq_number = 0;
+    new_aead_secret->key_seq_number = 1; // starts with 1
     new_aead_secret->from_pkt_number = 0;
 
     channel->aead_secrets[channel->nb_aead_secrets] = new_aead_secret;

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -2062,54 +2062,6 @@ int picoquic_tlscontext_create(picoquic_quic_t* quic, picoquic_cnx_t* cnx, uint6
     return ret;
 }
 
-/*
- * Creation of a TLS context for multicast
- */
-// CLEAN MC: Is this even needed?
-// int picoquic_tlscontext_create_mc(picoquic_quic_t* quic, picoquic_multicast_channel_t* channel, unsigned int client_mode)
-// {
-//     int ret = 0;
-//     /* allocate a context structure, but only if checks are correct */
-//     picoquic_tls_ctx_t* ctx = NULL;
-
-//     if (!client_mode && ((ptls_context_t*)quic->tls_master_ctx)->encrypt_ticket == NULL) {
-//         /* A server side connection, but no cert/key where given for the master context */
-//         ret = PICOQUIC_ERROR_TLS_SERVER_CON_WITHOUT_CERT;
-//     }
-//     else {
-//         ctx = (picoquic_tls_ctx_t*)malloc(sizeof(picoquic_tls_ctx_t));
-//         if (ctx == NULL) {
-//             ret = PICOQUIC_ERROR_MEMORY;
-//         }
-//     }
-
-//     /* Create the TLS context */
-//     if (ctx != NULL) {
-//         memset(ctx, 0, sizeof(picoquic_tls_ctx_t));
-//         ctx->ext_data_size = PICOQUIC_TRANSPORT_PARAMETERS_MAX_SIZE;
-//         if (!client_mode && quic->test_large_server_flight) {
-//             ctx->ext_data_size += 4096;
-//         }
-//         ctx->ext_data = (uint8_t*)malloc(ctx->ext_data_size);
-//         ctx->alpn_vec = (ptls_iovec_t*)malloc(sizeof(ptls_iovec_t) * PICOQUIC_ALPN_NUMBER_MAX);
-//         if (ctx->ext_data == NULL || ctx->alpn_vec == NULL) {
-//             ret = -1;
-//         }
-//         else {
-//             ctx->alpn_vec_size = PICOQUIC_ALPN_NUMBER_MAX;
-//             ctx->client_mode = client_mode;
-//         }
-//     }
-
-//     if (channel->mc_tls_ctx != NULL) {
-//         picoquic_tlscontext_free(channel->mc_tls_ctx);
-//     }
-
-//     channel->mc_tls_ctx = (void*)ctx;
-
-//     return ret;
-// }
-
 /* Set the log event to record keys for use by Wireshark.
  */
 

--- a/picoquic/transport.c
+++ b/picoquic/transport.c
@@ -632,10 +632,6 @@ int picoquic_prepare_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
             bytes = picoquic_transport_param_type_flag_encode(bytes, bytes_max, picoquic_tp_multicast_server_support);
         } else {
             bytes = picoquic_encode_transport_param_multicast_client_params(bytes, bytes_max, &cnx->local_parameters.multicast_client_params);
-            // CLEAN MC: Debug prints
-            // uint8_t* bytes_before = bytes;
-            // int length = bytes - bytes_before;
-            // print_bits(bytes_before, length);
         }
     }
 

--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -1421,3 +1421,49 @@ void print_hex_bytes(const uint8_t *data, size_t len) {
         printf("%02X ", data[i]);
     }
 }
+
+void picoquic_multicast_integrity_split_list(picoquic_multicast_packet_integrity_t *source, picoquic_multicast_packet_integrity_t **front, picoquic_multicast_packet_integrity_t **back) {
+    picoquic_multicast_packet_integrity_t *slow = source;
+    picoquic_multicast_packet_integrity_t *fast = (picoquic_multicast_packet_integrity_t *)source->next;
+
+    while (fast) {
+        fast = (picoquic_multicast_packet_integrity_t *)fast->next;
+        if (fast) {
+            slow = (picoquic_multicast_packet_integrity_t *)slow->next;
+            fast = (picoquic_multicast_packet_integrity_t *)fast->next;
+        }
+    }
+
+    *front = source;
+    *back = (picoquic_multicast_packet_integrity_t *)slow->next;
+    slow->next = NULL;
+}
+
+picoquic_multicast_packet_integrity_t *picoquic_multicast_integrity_sorted_merge(picoquic_multicast_packet_integrity_t *a, picoquic_multicast_packet_integrity_t *b) {
+    if (!a) return b;
+    if (!b) return a;
+
+    if (a->packet_number <= b->packet_number) {
+        a->next = (struct picoquic_multicast_packet_integrity_t *)picoquic_multicast_integrity_sorted_merge((picoquic_multicast_packet_integrity_t *)a->next, b);
+        return a;
+    } else {
+        b->next = (struct picoquic_multicast_packet_integrity_t *)picoquic_multicast_integrity_sorted_merge(a, (picoquic_multicast_packet_integrity_t *)b->next);
+        return b;
+    }
+}
+
+void picoquic_multicast_integrity_merge_sort(picoquic_multicast_packet_integrity_t **head_ref) {
+    picoquic_multicast_packet_integrity_t *head = *head_ref;
+    picoquic_multicast_packet_integrity_t *a;
+    picoquic_multicast_packet_integrity_t *b;
+
+    if (!head || !head->next)
+        return; // 0 or 1 element
+
+    picoquic_multicast_integrity_split_list(head, &a, &b);
+
+    picoquic_multicast_integrity_merge_sort(&a);
+    picoquic_multicast_integrity_merge_sort(&b);
+
+    *head_ref = picoquic_multicast_integrity_sorted_merge(a, b);
+}


### PR DESCRIPTION
`MC_LEAVE` frame implementation:

* Implement `MC_LEAVE` frame
* State handling with `MC_STATE(Left)`
* Log `MC_LEAVE` frame

Implement leave process:

* Add check which is the highest received multicast packet number hash before first packet loss
* Wait for last packet and hash to arrive (specified by `after_packet_number` by server) and only then leave channel as client
* Timeout after 3 seconds if final package is not arriving, just leave

Packet loop / wake improvements:

* Improve state management and wake management to avoid unwanted delays in unicast frame delivery
* Improve wake handling and introduce threshold wake

Other changes:

* Change multicast sequence numbers to start with 1 instead of 0
* Fix `MC_INTEGRITY` skip method and add alternative skip method for `MC_INTEGRITY` with static hash length
* Some cleanup of resolved todos, fix naming conventions in application