### PR TITLE
Finish `MC_RETIRE` frame support and add methods for shutdown

### DIFF
--- a/loglib/qlog.c
+++ b/loglib/qlog.c
@@ -1465,7 +1465,7 @@ void qlog_mc_retire_frame(FILE* f, bytestream* s)
 
     uint64_t after_packet_number = 0;
     byteread_vint(s, &after_packet_number);
-    fprintf(f, ", \"after_packet_number\": %"PRIu64"", after_packet_number);
+    fprintf(f, "\", \"after_packet_number\": %"PRIu64"", after_packet_number);
 }
 
 void qlog_mc_state_frame(FILE* f, bytestream* s)

--- a/multicast_sample/multicast_client.c
+++ b/multicast_sample/multicast_client.c
@@ -45,6 +45,7 @@ typedef struct st_multicast_client_ctx_t
     FILE *F;
     size_t bytes_received;
     unsigned int is_stream_finished : 1;
+    unsigned int exiting : 1;
 } multicast_client_ctx_t;
 
 /* Close file and free context */
@@ -210,8 +211,10 @@ int multicast_client_callback(picoquic_cnx_t *cnx,
             fprintf(stdout, "app: Received request to close connection\n");
         case picoquic_callback_multicast_left:
             fprintf(stdout, "app: Left the multicast channel, stop receiving\n");
+            client_ctx->exiting = 1;
         case picoquic_callback_multicast_retired:
             fprintf(stdout, "app: Retired the multicast client, stop receiving\n");
+            client_ctx->exiting = 1;
         case picoquic_callback_application_close:
             fprintf(stdout, "app: Received request to close application.\n");
             /* Remove the application callback */
@@ -289,7 +292,7 @@ static int multicast_client_loop_cb(picoquic_quic_t *quic, picoquic_packet_loop_
         case picoquic_packet_loop_alt_port:
             break;
         case picoquic_packet_loop_after_send:
-            if (picoquic_get_cnx_state(cb_ctx->cnx) == picoquic_state_disconnected) {
+            if (picoquic_get_cnx_state(cb_ctx->cnx) == picoquic_state_disconnected || cb_ctx->exiting == 1) {
                 ret = PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
             }
             break;

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -65,9 +65,13 @@ int picoquic_process_ack_of_mc_join_frame(picoquic_cnx_t* cnx, const uint8_t* by
     size_t bytes_size, size_t* consumed);
 int picoquic_process_ack_of_mc_leave_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
     size_t bytes_size, size_t* consumed);
+int picoquic_process_ack_of_mc_retire_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
+    size_t bytes_size, size_t* consumed);
 int picoquic_check_mc_join_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes, 
     const uint8_t* bytes_max, int* no_need_to_repeat);
 int picoquic_check_mc_leave_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes,
+    const uint8_t* bytes_max, int* no_need_to_repeat);
+int picoquic_check_mc_retire_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes,
     const uint8_t* bytes_max, int* no_need_to_repeat);
 int picoquic_process_ack_of_mc_state_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
     size_t bytes_size, uint64_t ftype, size_t* consumed);
@@ -3659,6 +3663,9 @@ int picoquic_check_frame_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes,
                 case picoquic_frame_type_mc_leave:
                     ret = picoquic_check_mc_leave_needs_repeat(cnx, bytes, p_bytes_max, no_need_to_repeat);
                     break;
+                case picoquic_frame_type_mc_retire:
+                    ret = picoquic_check_mc_retire_needs_repeat(cnx, bytes, p_bytes_max, no_need_to_repeat);
+                    break;
                 case picoquic_frame_type_mc_state_multicast:
                 case picoquic_frame_type_mc_state_application:
                     ret = picoquic_check_mc_state_needs_repeat(cnx, bytes, p_bytes_max, no_need_to_repeat);
@@ -3837,6 +3844,10 @@ void picoquic_process_ack_of_frames(picoquic_cnx_t* cnx, picoquic_packet_t* p,
             break;
         case picoquic_frame_type_mc_leave:
             ret = picoquic_process_ack_of_mc_leave_frame(cnx, &p->bytes[byte_index], p->length - byte_index, &frame_length);
+            byte_index += frame_length;
+            break;
+        case picoquic_frame_type_mc_retire:
+            ret = picoquic_process_ack_of_mc_retire_frame(cnx, &p->bytes[byte_index], p->length - byte_index, &frame_length);
             byte_index += frame_length;
             break;
         case picoquic_frame_type_mc_state_multicast:
@@ -4439,8 +4450,9 @@ const uint8_t* picoquic_decode_connection_close_frame(picoquic_cnx_t* cnx, const
         picoquic_state_enum old_state = cnx->cnx_state;
         cnx->cnx_state = (cnx->cnx_state < picoquic_state_client_ready_start || cnx->crypto_context[picoquic_epoch_1rtt].aead_decrypt == NULL) ? picoquic_state_disconnected : picoquic_state_closing_received;
 
-        // TODO MC: What happens with active multicast channels when the unicast cnx is closed by remote?
-
+        if (cnx->is_multicast_enabled == 1) {
+            picoquic_multicast_handle_cnx_close(cnx);
+        }
         if (cnx->callback_fn != NULL && cnx->cnx_state != old_state && cnx->cnx_state == picoquic_state_disconnected) {
             (void)(cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx, NULL);
         }
@@ -4483,6 +4495,9 @@ const uint8_t* picoquic_decode_application_close_frame(picoquic_cnx_t* cnx, cons
     }
     else {
         cnx->cnx_state = (cnx->cnx_state < picoquic_state_client_ready_start) ? picoquic_state_disconnected : picoquic_state_closing_received;
+        if (cnx->is_multicast_enabled == 1) {
+            picoquic_multicast_handle_cnx_close(cnx);
+        }
         if (cnx->callback_fn) {
             (void)(cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_application_close, cnx->callback_ctx, NULL);
         }
@@ -7626,10 +7641,20 @@ const uint8_t* picoquic_decode_mc_state_frame(picoquic_cnx_t* cnx, const uint8_t
     // Server callback when state changed
     if (state_before != channel_found->state) {
         if (channel_found->state == picoquic_mc_state_join_attempted) {
-            cnx->callback_fn(cnx, 0, NULL, 0, picoquic_callback_multicast_join_attempted, cnx->callback_ctx, &channel_found->channel->channel_id);
+            if (cnx->callback_fn != NULL) {
+                cnx->callback_fn(cnx, 0, NULL, 0, picoquic_callback_multicast_join_attempted, cnx->callback_ctx, &channel_found->channel->channel_id);
+            }
         }
         if (channel_found->state == picoquic_mc_state_left) {
-            cnx->callback_fn(cnx, 0, NULL, 0, picoquic_callback_multicast_left, cnx->callback_ctx, &channel_found->channel->channel_id);
+            if (cnx->callback_fn != NULL) {
+                cnx->callback_fn(cnx, 0, NULL, 0, picoquic_callback_multicast_left, cnx->callback_ctx, &channel_found->channel->channel_id);
+            }
+        }
+        if (channel_found->state == picoquic_mc_state_retired) {
+            picoquic_multicast_handle_client_retired(channel_found->channel);
+            if (cnx->callback_fn != NULL) {
+                cnx->callback_fn(cnx, 0, NULL, 0, picoquic_callback_multicast_retired, cnx->callback_ctx, &channel_found->channel->channel_id);
+            }
         }
     }
 
@@ -8801,6 +8826,207 @@ int picoquic_check_mc_leave_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* byt
     return ret;
 }
 
+/*
+ * MC_RETIRE frame
+ */
+
+uint8_t* picoquic_format_mc_retire_frame(uint8_t* bytes, uint8_t* bytes_max, picoquic_mc_channel_in_cnx_t* ch_in_cnx, int * more_data)
+{
+    uint8_t* bytes0 = bytes;
+    
+    // Frame type
+    // Channel ID Length
+    if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, picoquic_frame_type_mc_retire)) == NULL
+        || (bytes = picoquic_frames_uint8_encode(bytes, bytes_max, ch_in_cnx->channel->channel_id.id_len)) == NULL) {
+        *more_data = 1;
+        return bytes0;
+    } 
+
+    // Channel ID
+    uint8_t bytes_copied = picoquic_format_multicast_channel_id(bytes, bytes_max - bytes, &ch_in_cnx->channel->channel_id);
+    if (bytes_copied == 0) {
+        *more_data = 1;
+        return bytes0;
+    } else {
+        bytes += bytes_copied;
+    }
+
+    // After Packet number
+    if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, ch_in_cnx->channel->pkt_ctx.send_sequence - 1)) == NULL) {
+        *more_data = 1;
+        return bytes0;
+    } 
+
+    if (ch_in_cnx->state < picoquic_mc_state_retire_pending) {
+        ch_in_cnx->state = picoquic_mc_state_retire_pending;
+    }
+
+    return bytes;
+}
+
+const uint8_t* picoquic_skip_mc_retire_frame(const uint8_t* bytes, const uint8_t* bytes_max) {
+    uint8_t ch_id_length = 0;
+
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &ch_id_length)) != NULL && // channel id length
+        (bytes = picoquic_frames_fixed_skip(bytes, bytes_max, (uint64_t)ch_id_length)) != NULL) { // channel id
+            bytes = picoquic_frames_varint_skip(bytes, bytes_max); // after packet number
+        }
+
+    return bytes;
+}
+
+const uint8_t* picoquic_decode_mc_retire_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, 
+    const uint8_t* bytes_max, uint64_t current_time) 
+{
+    const uint8_t* bytes0 = bytes;
+
+    if (!cnx->is_multicast_enabled || !cnx->client_mode) {
+        picoquic_connection_error_ex(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, picoquic_frame_type_mc_retire, "Received unexpected MC_RETIRE frame\n");
+        return NULL;
+    }
+
+    uint8_t id_len;
+    picoquic_multicast_channel_id_t channel_id;
+
+    // Channel ID Length
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &id_len)) == NULL) {
+        return NULL;
+    }
+
+    // Channel ID
+    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes, id_len, &channel_id);
+    if (bytes_copied == 0) {
+        return NULL;
+    } 
+
+    picoquic_mc_channel_in_cnx_t* channel_found = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx);
+    if (channel_found == NULL) {
+        fprintf(stderr, "Error: Received a MC_RETIRE, but no mc channel was found in the connection\n");
+        return picoquic_skip_mc_retire_frame(bytes0, bytes_max);
+    }
+
+    bytes += bytes_copied;
+
+    uint64_t after_packet_number;
+
+    if ((bytes = picoquic_frames_varint_decode(bytes, bytes_max, &after_packet_number)) == NULL
+    ) {
+        return NULL;
+    }
+
+    uint64_t highest_verified = picoquic_multicast_get_latest_packet_number_verified(channel_found->channel);
+
+    if (highest_verified < UINT64_MAX) {
+        fprintf(stdout, "Highest pn verified before first loss: %lu\n", highest_verified);
+    } else {
+        fprintf(stdout, "Highest pn verified before first loss: NULL\n");
+    }
+
+    if (highest_verified < UINT64_MAX && after_packet_number > highest_verified) {
+        channel_found->retire_after_packet_number = after_packet_number;
+        channel_found->retire_received_at = current_time;
+        fprintf(stderr, "Received a MC_RETIRE frame with future packet number (%li), wait until it arrives\n", after_packet_number);
+    }
+
+    if (channel_found->state < picoquic_mc_state_retire_waiting) {
+        channel_found->state = picoquic_mc_state_retire_waiting;
+    }
+
+    picoquic_multicast_update_leave_retired_waiting(channel_found, current_time);
+
+    return bytes;
+}
+
+int picoquic_process_ack_of_mc_retire_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,
+    size_t bytes_size, size_t* consumed)
+{
+    const uint8_t* bytes_first = bytes;
+    const uint8_t* bytes_max = bytes + bytes_size;
+
+    // Skip frame type
+    const uint8_t* bytes_after_ftype = bytes = picoquic_frames_varint_skip(bytes, bytes_max);
+
+    uint8_t id_len;
+    picoquic_multicast_channel_id_t channel_id;
+    uint64_t seq_number;
+
+    if ((bytes = picoquic_frames_uint8_decode(bytes, bytes_max, &id_len)) == NULL) {
+        return -1;
+    }
+
+    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes, id_len, &channel_id);
+
+    if (bytes_copied == 0) {
+        return -1;
+    }
+
+    bytes += bytes_copied;
+    bytes = picoquic_frames_varint_decode(bytes, bytes_max, &seq_number);
+    
+    if (bytes == NULL) {
+        return -1;
+    }
+
+    int ret = 0;
+    const uint8_t* bytes_next = picoquic_skip_mc_retire_frame(bytes_after_ftype, bytes_max);
+
+    if (bytes_next == NULL) {
+        return -1;
+    }
+    else {
+        picoquic_mc_channel_in_cnx_t* ch_in_cnx = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx);
+        if (ch_in_cnx == NULL) {
+            return -1;
+        }
+        ch_in_cnx->mc_retire_acked = 1;
+        *consumed = bytes_next - bytes_first;
+    }
+    
+    fprintf(stdout, "ACK of MC_RETIRE successfully processed\n");
+    return ret;
+}
+
+int picoquic_check_mc_retire_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes, const uint8_t* bytes_max, int* no_need_to_repeat)
+{
+    int ret = 0;
+    const uint8_t* bytes_parsing = bytes;
+    uint8_t id_len;
+    picoquic_multicast_channel_id_t channel_id;
+    *no_need_to_repeat = 0;
+
+    if ((bytes_parsing = picoquic_frames_uint8_decode(bytes_parsing, bytes_max, &id_len)) == NULL) {
+        *no_need_to_repeat = 1;
+        return -1;
+    }
+
+    uint8_t bytes_copied = picoquic_parse_multicast_channel_id(bytes_parsing, id_len, &channel_id);
+
+    if (bytes_copied == 0) {
+        *no_need_to_repeat = 1;
+        return -1;
+    }
+
+    picoquic_mc_channel_in_cnx_t* ch_in_cnx;
+
+    if ((ch_in_cnx = picoquic_find_multicast_channel_in_cnx(&channel_id, cnx)) == NULL) {
+        /* If the channel is not in the connection (anymore?), no need to repeat this frame. */
+        *no_need_to_repeat = 1;
+    }
+    else if (ch_in_cnx->mc_retire_acked > 0) 
+    {
+        /* If MC_RETIRE was acked, do not repeat */
+        *no_need_to_repeat = 1;
+    }
+
+    if (*no_need_to_repeat == 0) {
+        fprintf(stdout, "MC_RETIRE needs repeat\n");
+    } else {
+        fprintf(stdout, "MC_RETIRE do not need repeat\n");
+    }
+
+    return ret;
+}
+
 /* BDP frames as defined in https://tools.ietf.org/html/draft-kuhn-quic-0rtt-bdp-09
 */
 
@@ -9464,6 +9690,10 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, picoquic_path_t * path_x, const 
                             fprintf(stdout, "Got MC_LEAVE frame\n");
                             bytes = picoquic_decode_mc_leave_frame(cnx, bytes, bytes_max, current_time);
                             break;
+                        case picoquic_frame_type_mc_retire:
+                            fprintf(stdout, "Got MC_RETIRE frame\n");
+                            bytes = picoquic_decode_mc_retire_frame(cnx, bytes, bytes_max, current_time);
+                            break;
                         default:
                             /* Not implemented yet! */
                             picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, frame_id64);
@@ -9806,6 +10036,10 @@ int picoquic_skip_frame(const uint8_t* bytes, size_t bytes_maxsize, size_t* cons
                     break;
                 case picoquic_frame_type_mc_leave:
                     bytes = picoquic_skip_mc_leave_frame(bytes, bytes_max);
+                    *pure_ack = 0;
+                    break;
+                case picoquic_frame_type_mc_retire:
+                    bytes = picoquic_skip_mc_retire_frame(bytes, bytes_max);
                     *pure_ack = 0;
                     break;
                 case picoquic_frame_type_mc_state_multicast:

--- a/picoquic/logwriter.c
+++ b/picoquic/logwriter.c
@@ -570,6 +570,16 @@ static const uint8_t* picoquic_log_mc_leave_frame(FILE* f, const uint8_t* bytes,
     return bytes;
 }
 
+static const uint8_t* picoquic_log_mc_retire_frame(FILE* f, const uint8_t* bytes, const uint8_t* bytes_max)
+{
+    const uint8_t* bytes_begin = bytes;
+    bytes = picoquic_log_varint_skip(bytes, bytes_max);
+    bytes = picoquic_skip_mc_retire_frame(bytes, bytes_max);     
+    picoquic_binlog_frame(f, bytes_begin, bytes);
+
+    return bytes;
+}
+
 static const uint8_t* picoquic_log_mc_state_frame(FILE* f, const uint8_t* bytes, const uint8_t* bytes_max, uint64_t ftype)
 {
     const uint8_t* bytes_begin = bytes;
@@ -734,6 +744,9 @@ void picoquic_binlog_frames(FILE * f, const uint8_t* bytes, size_t length)
             break;
         case picoquic_frame_type_mc_leave:
             bytes = picoquic_log_mc_leave_frame(f, bytes, bytes_max);
+            break;
+        case picoquic_frame_type_mc_retire:
+            bytes = picoquic_log_mc_retire_frame(f, bytes, bytes_max);
             break;
         case picoquic_frame_type_mc_state_multicast:
         case picoquic_frame_type_mc_state_application:

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1448,6 +1448,7 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     uint64_t latest_state_sequence_available;
     uint64_t latest_limits_sequence_available;
     struct mcrx_subscription* mcrx_subscription;
+    struct mcrx_ctx* mcrx_ctx;
 
     // ack context
     picoquic_ack_context_t ack_ctx;
@@ -1457,13 +1458,13 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     int mc_join_acked;
     int mc_leave_acked;
     int mc_retire_acked;
-    int key_acked;                                              // At least one MC_KEY frame was acked
+    int key_acked;                                               // At least one MC_KEY frame was acked
     int mc_leave_scheduled;
     int mc_retire_scheduled;
-    uint64_t last_time_woken;                                        // When this cnx was last woken for sending multicast frames on unicast in the socket loop
+    uint64_t last_time_woken;                                    // When this cnx was last woken for sending multicast frames on unicast in the socket loop
     uint64_t latest_key_sequence_acked;
-    int first_mc_integrity_sent;                                // sent at least one mc_integrity frame (needed bc the first packet no is 0)
-    uint64_t mc_integrity_latest_pn_sent;                       // latest *multicast* packet number for which an integrity hash was sent
+    int first_mc_integrity_sent;                                 // sent at least one mc_integrity frame (needed bc the first packet no is 0)
+    uint64_t mc_integrity_latest_pn_sent;                        // latest *multicast* packet number for which an integrity hash was sent
     picoquic_multicast_integrity_ack_t** integrity_frames_acked; // stores info, which MC_INTEGRITY frames were ACKed by client
     size_t nb_integrity_frames_acked;
 
@@ -1472,12 +1473,12 @@ typedef struct st_picoquic_mc_channel_in_cnx_t {
     uint64_t latest_receive_time;
     picoquic_mc_state_enum state_scheduled;
     picoquic_mc_state_frame_enum state_frame_scheduled;
-    int state_reason_scheduled;         // reason code for scheduled state frame, could also be different from picoquic_mc_state_reason_enum choices
-    int mc_state_acked;                 // At least one MC_STATE frame was acked
-    int mc_limits_acked;                // At least one MC_LIMITS frame was acked
+    int state_reason_scheduled;          // reason code for scheduled state frame, could also be different from picoquic_mc_state_reason_enum choices
+    int mc_state_acked;                  // At least one MC_STATE frame was acked
+    int mc_limits_acked;                 // At least one MC_LIMITS frame was acked
     uint64_t latest_state_sequence_acked;
     uint64_t latest_limits_sequence_acked;
-    uint64_t leave_after_packet_number; // Send STATE(Left) after this packet number has been received
+    uint64_t leave_after_packet_number;  // Send STATE(Left) after this packet number has been received
     uint64_t retire_after_packet_number; // Send STATE(Retired) after this packet number has been received
     uint64_t leave_received_at;          // current_time when MC_LEAVE arrived (for timeout)
     uint64_t retire_received_at;         // current_time when MC_RETIRE arrived (for timeout)
@@ -1877,7 +1878,10 @@ void picoquic_queue_for_retransmit(picoquic_cnx_t* cnx, picoquic_path_t* path_x,
 picoquic_packet_t* picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet_context_t* pkt_ctx,
     picoquic_packet_t* p, int should_free,
     int add_to_data_repeat_queue);
+picoquic_packet_t* picoquic_dequeue_retransmit_packet_multicast(picoquic_multicast_channel_t* channel,
+    picoquic_packet_context_t * pkt_ctx, picoquic_packet_t* p, int should_free);
 void picoquic_dequeue_retransmitted_packet(picoquic_cnx_t* cnx, picoquic_packet_context_t* pkt_ctx, picoquic_packet_t* p);
+void picoquic_dequeue_retransmitted_packet_multicast(picoquic_multicast_channel_t* channel, picoquic_packet_context_t* pkt_ctx, picoquic_packet_t* p);
 
 /* Reset the connection context, e.g. after retry */
 int picoquic_reset_cnx(picoquic_cnx_t* cnx, uint64_t current_time);
@@ -2318,6 +2322,8 @@ int picoquic_wake_for_multicast_frames(picoquic_quic_t* quic,
     uint64_t threshold, uint64_t current_time, int64_t* delta_t);
 void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_t* ch_in_cnx, uint64_t current_time);
 uint64_t picoquic_multicast_get_latest_packet_number_verified(picoquic_multicast_channel_t* channel);
+void picoquic_multicast_handle_client_retired(picoquic_multicast_channel_t* channel);
+void picoquic_multicast_handle_cnx_close(picoquic_cnx_t* cnx);
 
 picoquic_mc_channel_in_cnx_t* picoquic_add_channel_to_cnx(picoquic_cnx_t* cnx, 
     picoquic_multicast_channel_t* channel);
@@ -2347,7 +2353,11 @@ const uint8_t* picoquic_skip_mc_ack_frame(const uint8_t* bytes,
     const uint8_t* bytes_max, int is_ecn);
 uint8_t* picoquic_format_mc_leave_frame(uint8_t* bytes, uint8_t* bytes_max, 
     picoquic_mc_channel_in_cnx_t* ch_in_cnx, int * more_data);
+uint8_t* picoquic_format_mc_retire_frame(uint8_t* bytes, uint8_t* bytes_max, 
+    picoquic_mc_channel_in_cnx_t* ch_in_cnx, int * more_data);
 const uint8_t* picoquic_skip_mc_leave_frame(const uint8_t* bytes, 
+    const uint8_t* bytes_max);
+const uint8_t* picoquic_skip_mc_retire_frame(const uint8_t* bytes, 
     const uint8_t* bytes_max);
 
 int picoquic_is_ack_needed_multicast(picoquic_cnx_t* cnx, uint64_t current_time, uint64_t* next_wake_time,

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -953,7 +953,7 @@ int picoquic_wake_for_multicast_frames(picoquic_quic_t* quic, uint64_t threshold
         if (channel->nb_used_in_cnx > 0) {
             for (int j = 0; j < channel->nb_used_in_cnx; j++) {
                 picoquic_mc_channel_in_cnx_t* ch_in_cnx = channel->used_in_cnx[j];
-                if (ch_in_cnx->state < picoquic_mc_state_left) { // ENHANCE MC: Clarify when MC_INTEGRITY frames still need to be sent
+                if (ch_in_cnx->state < picoquic_mc_state_retired) {
                     
                     // In client mode, if in waiting state, wake more often, because client is waiting for timeout to leave channel
                     if (channel->client_mode) {
@@ -967,22 +967,24 @@ int picoquic_wake_for_multicast_frames(picoquic_quic_t* quic, uint64_t threshold
                     // ENHANCE MC: Check if the receivers are really active (sent MC_ACK frames in the recent past)
                     // -> if not, make delay longer
 
-                    // Real Wake: Wake cnx if we really know that we need to send something (integrity, leave or retire frame)
-                    if ((channel->packet_integrity_last != NULL && ch_in_cnx->mc_integrity_latest_pn_sent < channel->packet_integrity_last->packet_number)
-                        || ch_in_cnx->mc_leave_scheduled || ch_in_cnx->mc_retire_scheduled) {
-                            ch_in_cnx->last_time_woken = current_time;
+                    if (ch_in_cnx->state < picoquic_mc_state_left) {
+                        // Real Wake: Wake cnx if we really know that we need to send something (integrity, leave or retire frame)
+                        if ((channel->packet_integrity_last != NULL && ch_in_cnx->mc_integrity_latest_pn_sent < channel->packet_integrity_last->packet_number)
+                            || ch_in_cnx->mc_leave_scheduled || ch_in_cnx->mc_retire_scheduled) {
+                                ch_in_cnx->last_time_woken = current_time;
+                                picoquic_reinsert_by_wake_time(quic, ch_in_cnx->cnx, current_time);
+                        // Threshold wake: Also wake a few more times if the last real wake was not too long ago, to make sure we really 
+                        // didn't miss anything before going into the long 10 seconds break of picoquic
+                        } else if (ch_in_cnx->last_time_woken + wake_after_active >= current_time) {
                             picoquic_reinsert_by_wake_time(quic, ch_in_cnx->cnx, current_time);
-                    // Threshold wake: Also wake a few more times if the last real wake was not too long ago, to make sure we really 
-                    // didn't miss anything before going into the long 10 seconds break of picoquic
-                    } else if (ch_in_cnx->last_time_woken + wake_after_active >= current_time) {
-                        picoquic_reinsert_by_wake_time(quic, ch_in_cnx->cnx, current_time);
-                    }
+                        }
 
-                    if (channel->packet_integrity_last != NULL &&
-                        ch_in_cnx->mc_integrity_latest_pn_sent + threshold < channel->packet_integrity_last->packet_number) {
-                        *delta_t = 0;
-                    } else if (*delta_t > active_max_delta_t) {
-                        *delta_t = active_max_delta_t;
+                        if (channel->packet_integrity_last != NULL &&
+                            ch_in_cnx->mc_integrity_latest_pn_sent + threshold < channel->packet_integrity_last->packet_number) {
+                            *delta_t = 0;
+                        } else if (*delta_t > active_max_delta_t) {
+                            *delta_t = active_max_delta_t;
+                        }
                     }
                 }
             }
@@ -1180,6 +1182,8 @@ int picoquic_join_mc_channel(picoquic_cnx_t* cnx, picoquic_multicast_channel_id_
             ret = -1;
         }
     }
+
+    ch_in_cnx->mcrx_ctx = ctx;
     
     if (ret != 0) {
         ch_in_cnx->state_frame_scheduled = picoquic_mc_state_frame_declined_join;
@@ -1228,6 +1232,15 @@ uint64_t picoquic_multicast_get_latest_packet_number_verified(picoquic_multicast
     return UINT64_MAX;
 }
 
+void picoquic_multicast_remove_subscription(picoquic_mc_channel_in_cnx_t* ch) {
+    if (ch->mcrx_subscription != NULL) {
+        picoquic_mcrx_leave(ch->mcrx_subscription);
+    }
+    if (ch->mcrx_ctx != NULL) {
+        picoquic_mcrx_cleanup(&ch->mcrx_ctx);
+    }
+}
+
 // Schedule State(Left) / State(Retired) on client when in retire_waiting / leave_waiting states and final packet number has been received
 void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_t* ch_in_cnx, uint64_t current_time) {
     uint64_t highest_verified = picoquic_multicast_get_latest_packet_number_verified(ch_in_cnx->channel);
@@ -1240,7 +1253,8 @@ void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_
         ch_in_cnx->state_scheduled = picoquic_mc_state_retired;
         ch_in_cnx->state_frame_scheduled = picoquic_mc_state_frame_retired;
         ch_in_cnx->state_reason_scheduled = picoquic_mc_state_reason_requested_by_server;
-    } 
+        picoquic_multicast_remove_subscription(ch_in_cnx);
+    }
     else if (ch_in_cnx->state == picoquic_mc_state_leave_waiting && 
         ((highest_verified < UINT64_MAX && highest_verified >= ch_in_cnx->leave_after_packet_number) || ch_in_cnx->leave_received_at + timeout <= current_time)
     ) {
@@ -1248,6 +1262,7 @@ void picoquic_multicast_update_leave_retired_waiting(picoquic_mc_channel_in_cnx_
         ch_in_cnx->state_scheduled = picoquic_mc_state_left;
         ch_in_cnx->state_frame_scheduled = picoquic_mc_state_frame_left;
         ch_in_cnx->state_reason_scheduled = picoquic_mc_state_reason_requested_by_server;
+        picoquic_multicast_remove_subscription(ch_in_cnx);
     }
 }
 
@@ -1301,6 +1316,46 @@ int picoquic_schedule_mc_retire(picoquic_multicast_channel_t* channel, picoquic_
     }
 
     return 0;
+}
+
+// Handle process on the server when a client sent MC_STATE(Retired)
+void picoquic_multicast_handle_client_retired(picoquic_multicast_channel_t* channel) 
+{
+    int non_retired_clients = 0;
+
+    for (int i = 0; i < channel->nb_used_in_cnx; i++) {
+        if (channel->used_in_cnx[i]->state < picoquic_mc_state_retired) {
+            non_retired_clients++;
+        }
+    }
+
+    if (non_retired_clients == 0) {
+        channel->is_retired = 1;
+    }
+}
+
+// Handle multicast state on the server when a client closed the connection
+void picoquic_multicast_handle_cnx_close(picoquic_cnx_t* cnx) 
+{
+    for (int i = 0; i < cnx->nb_mc_channels; i++) {
+        picoquic_mc_channel_in_cnx_t* ch_in_cnx = cnx->mc_channels[i];
+        picoquic_multicast_channel_t* channel = ch_in_cnx->channel;
+        int non_retired_clients = 0;
+
+        ch_in_cnx->state = picoquic_mc_state_retired;
+
+        if (cnx->client_mode == 0) {
+            for (int i = 0; i < channel->nb_used_in_cnx; i++) {
+                if (channel->used_in_cnx[i]->state < picoquic_mc_state_retired) {
+                    non_retired_clients++;
+                }
+            }
+
+            if (non_retired_clients == 0) {
+                channel->is_retired = 1;
+            }
+        }
+    }
 }
 
 void picoquic_set_default_address_discovery_mode(picoquic_quic_t* quic, int mode)
@@ -1492,6 +1547,10 @@ void picoquic_free(picoquic_quic_t* quic)
             free(quic->tls_master_ctx);
             quic->tls_master_ctx = NULL;
         }
+
+        /* Delete multicast channel pointers, the content are already
+        deleted in picoquic_delete_cnx() above */
+        free(quic->mc_channels);
 
         /* Close the logs */
         picoquic_log_close_logs(quic);
@@ -5040,6 +5099,25 @@ void picoquic_reset_packet_context(picoquic_cnx_t* cnx,
     pkt_ctx->ecn_ce_total_remote = 0;
 }
 
+void picoquic_reset_packet_context_multicast(picoquic_multicast_channel_t* channel,
+    picoquic_packet_context_t * pkt_ctx)
+{
+    while (pkt_ctx->pending_last != NULL) {
+        (void)picoquic_dequeue_retransmit_packet_multicast(channel, pkt_ctx, pkt_ctx->pending_last, 1);
+    }
+    
+    while (pkt_ctx->retransmitted_newest != NULL) {
+        picoquic_dequeue_retransmitted_packet_multicast(channel, pkt_ctx, pkt_ctx->retransmitted_newest);
+    }
+
+    pkt_ctx->retransmitted_oldest = NULL;
+
+    /* Reset the ECN data */
+    pkt_ctx->ecn_ect0_total_remote = 0;
+    pkt_ctx->ecn_ect1_total_remote = 0;
+    pkt_ctx->ecn_ce_total_remote = 0;
+}
+
 /*
 * Reset the connection after an incoming retry packet.
 *
@@ -5118,7 +5196,11 @@ int picoquic_connection_error_ex(picoquic_cnx_t* cnx, uint64_t local_error, uint
         cnx->local_error = local_error;
         cnx->local_error_reason = local_reason;
         cnx->cnx_state = picoquic_state_disconnecting;
-        // TODO MC: Set multicast joined state also to "leaving" or similar
+
+        if(cnx->is_multicast_enabled) {
+            picoquic_multicast_handle_cnx_close(cnx);
+        }
+
     } else if (cnx->cnx_state < picoquic_state_server_false_start) {
         if (cnx->cnx_state != picoquic_state_handshake_failure &&
             cnx->cnx_state != picoquic_state_handshake_failure_resend) {
@@ -5186,6 +5268,107 @@ void picoquic_delete_sooner_packets(picoquic_cnx_t* cnx)
         packet = next_packet;
     }
     cnx->first_sooner = NULL;
+}
+
+void picoquic_delete_mc_channel_in_cnx_list(picoquic_mc_channel_in_cnx_t** channels, int nb_channels);
+
+void picoquic_delete_multicast_channel(picoquic_multicast_channel_t* channel) {
+    if (channel == NULL) {
+        return;
+    }
+
+    if (channel->nb_used_in_cnx > 0) {
+        picoquic_delete_mc_channel_in_cnx_list(channel->used_in_cnx, channel->nb_used_in_cnx);
+    }
+
+    for (int i = 0; i < channel->nb_aead_secrets; i++) {
+        free(channel->aead_secrets[i]);
+    }
+
+    picoquic_crypto_context_free(&channel->crypto_context);
+
+    while (channel->p_first_packet != NULL) {
+        picoquic_packet_t * p = channel->p_first_packet->packet_previous;
+        free(channel->p_first_packet);
+        channel->p_first_packet = p;
+        channel->nb_packets_allocated--;
+        channel->nb_packets_in_pool--;
+    }
+
+    picoquic_reset_packet_context_multicast(channel, &channel->pkt_ctx);
+
+    while(channel->packet_integrity_first != NULL) {
+        picoquic_multicast_packet_integrity_t* next = (picoquic_multicast_packet_integrity_t*)channel->packet_integrity_first->next;
+        free(channel->packet_integrity_first->hash);
+        free(channel->packet_integrity_first);
+        channel->packet_integrity_first = next;
+    }
+    channel->packet_integrity_last = NULL;
+
+    // TODO MC: Clean stream data structs in multicast_channel_t here
+
+    while (channel->first_datagram != NULL) {
+        picoquic_delete_misc_or_dg(&channel->first_datagram, &channel->last_datagram, channel->first_datagram);
+    }
+}
+
+void picoquic_remove_mc_channel_in_cnx_from_element(picoquic_mc_channel_in_cnx_t** channels,
+     int* nb_channels, picoquic_mc_channel_in_cnx_t* channel_to_remove
+) {
+    int index = -1;
+
+    for (int i = 0; i < *nb_channels; i++) {
+        if (channels[i] == channel_to_remove) {
+            index = i;
+            break;
+        }
+    }
+
+    if (index == -1) {
+        return;
+    }
+
+    for (int i = index; i < *nb_channels - 1; i++) {
+        channels[i] = channels[i + 1];
+    }
+
+    channels[*nb_channels - 1] = NULL;
+
+    (*nb_channels)--;
+}
+
+void picoquic_delete_mc_channel_in_cnx_list(picoquic_mc_channel_in_cnx_t** channels, int nb_channels) {
+    for (int i = 0; i < nb_channels; i++) {
+        picoquic_mc_channel_in_cnx_t* ch_in_cnx = channels[i];
+
+        picoquic_multicast_remove_subscription(ch_in_cnx);
+        
+        for (int j = 0; j < ch_in_cnx->nb_integrity_frames_acked; j++) {
+            free(ch_in_cnx->integrity_frames_acked[j]);
+        }
+
+        while (ch_in_cnx->awaiting_integrity_check_first != NULL) {
+            picoquic_multicast_packet_t* integrity_wait_next = (picoquic_multicast_packet_t*)ch_in_cnx->awaiting_integrity_check_first->next;
+            free(ch_in_cnx->awaiting_integrity_check_first->hash);
+            free(ch_in_cnx->awaiting_integrity_check_first->bytes);
+            free(ch_in_cnx->awaiting_integrity_check_first);
+            ch_in_cnx->awaiting_integrity_check_first = integrity_wait_next;
+        }
+        ch_in_cnx->awaiting_integrity_check_last = NULL;
+
+        if (ch_in_cnx->channel != NULL) {
+            picoquic_multicast_channel_t* channel = ch_in_cnx->channel;
+            picoquic_remove_mc_channel_in_cnx_from_element(
+                ch_in_cnx->channel->used_in_cnx, &ch_in_cnx->channel->nb_used_in_cnx,
+                ch_in_cnx);
+
+            if (channel->nb_used_in_cnx == 0) {
+                picoquic_delete_multicast_channel(channel);
+            }
+        }
+
+        free(ch_in_cnx);
+    }
 }
 
 void picoquic_delete_cnx(picoquic_cnx_t* cnx)
@@ -5280,6 +5463,10 @@ void picoquic_delete_cnx(picoquic_cnx_t* cnx)
 
         picoquic_unregister_net_icid(cnx);
         picoquic_unregister_net_secret(cnx);
+
+        // Remove multicast contexts
+        picoquic_delete_mc_channel_in_cnx_list(cnx->mc_channels, cnx->nb_mc_channels);
+        free(cnx->mc_channels);
 
         free(cnx);
     }

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1203,6 +1203,70 @@ void picoquic_queue_for_retransmit(picoquic_cnx_t* cnx, picoquic_path_t * path_x
     }
 }
 
+picoquic_packet_t* picoquic_dequeue_retransmit_packet_multicast(picoquic_multicast_channel_t* channel, 
+    picoquic_packet_context_t * pkt_ctx, picoquic_packet_t* p, int should_free)
+{
+    size_t dequeued_length = p->length + p->checksum_overhead;
+
+    if (p->is_queued_for_retransmit) {
+        /* Remove from list */
+        if (p->packet_next == NULL) {
+            pkt_ctx->pending_last = p->packet_previous;
+        }
+        else {
+            p->packet_next->packet_previous = p->packet_previous;
+        }
+
+        if (p->packet_previous == NULL) {
+            pkt_ctx->pending_first = p->packet_next;
+        }
+        else {
+            p->packet_previous->packet_next = p->packet_next;
+        }
+        p->is_queued_for_retransmit = 0;
+    }
+
+    /* Account for bytes in transit, for congestion control */
+
+    if (p->send_path != NULL && !p->is_ack_trap) {
+        if (p->send_path->bytes_in_transit > dequeued_length) {
+            p->send_path->bytes_in_transit -= dequeued_length;
+        }
+        else {
+            p->send_path->bytes_in_transit = 0;
+        }
+        p->send_path->is_cc_data_updated = 1;
+    }
+
+    /* Replace head of preemptive repeat list if it was this packet. */
+    if (pkt_ctx->preemptive_repeat_ptr == p) {
+        pkt_ctx->preemptive_repeat_ptr = p->packet_next;
+    }
+
+    if (should_free || p->is_ack_trap) {
+        picoquic_recycle_packet_multicast(channel, p);
+        p = NULL;
+    }
+    else {
+        p->packet_previous = NULL;
+        /* add this packet to the retransmitted list */
+        if (pkt_ctx->retransmitted_oldest == NULL) {
+            pkt_ctx->retransmitted_newest = p;
+            pkt_ctx->retransmitted_oldest = p;
+            p->packet_next = NULL;
+        }
+        else {
+            pkt_ctx->retransmitted_newest->packet_previous = p;
+            p->packet_next = pkt_ctx->retransmitted_newest;
+            pkt_ctx->retransmitted_newest = p;
+        }
+        pkt_ctx->retransmitted_queue_size += 1;
+        p->is_queued_for_spurious_detection = 1;
+    }
+
+    return p;
+}
+
 picoquic_packet_t* picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, 
     picoquic_packet_context_t * pkt_ctx, picoquic_packet_t* p, int should_free,
     int add_to_data_repeat_queue)
@@ -1275,6 +1339,32 @@ picoquic_packet_t* picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx,
     }
 
     return p;
+}
+
+void picoquic_dequeue_retransmitted_packet_multicast(picoquic_multicast_channel_t* channel, picoquic_packet_context_t* pkt_ctx, picoquic_packet_t* p)
+{
+    pkt_ctx->retransmitted_queue_size -= 1;
+    if (p->packet_previous == NULL) {
+        pkt_ctx->retransmitted_newest = p->packet_next;
+    }
+    else {
+        p->packet_previous->packet_next = p->packet_next;
+    }
+
+    if (p->packet_next == NULL) {
+        pkt_ctx->retransmitted_oldest = p->packet_previous;
+    }
+    else {
+        p->packet_next->packet_previous = p->packet_previous;
+    }
+
+    /* Packets can be queued simultaneously for data repeat and 
+    * for detection of spurious losses, so should only be recycled
+    * when removed from both queues */
+    p->is_queued_for_spurious_detection = 0;
+    if (!p->is_queued_for_data_repeat) {
+        picoquic_recycle_packet_multicast(channel, p);
+    }
 }
 
 void picoquic_dequeue_retransmitted_packet(picoquic_cnx_t* cnx, picoquic_packet_context_t* pkt_ctx, picoquic_packet_t* p)
@@ -3234,14 +3324,13 @@ uint8_t * picoquic_prepare_multicast_leave_retire_frames(picoquic_cnx_t* cnx,
             }
             // if channel retire scheduled
             if (ch->mc_retire_scheduled) {
-                // TODO MC: Implement MC_RETIRE frame
-                // uint8_t *bytes_next = picoquic_format_mc_retire_frame(bytes, bytes_max, ch, more_data);
-                // if (bytes_next > bytes) {
-                //     *is_pure_ack = 0;
-                //     bytes = bytes_next;
-                //     ch->state = picoquic_mc_state_retire_pending; 
-                //     ch->mc_retire_scheduled = 0;
-                // }
+                uint8_t *bytes_next = picoquic_format_mc_retire_frame(bytes, bytes_max, ch, more_data);
+                if (bytes_next > bytes) {
+                    *is_pure_ack = 0;
+                    bytes = bytes_next;
+                    ch->state = picoquic_mc_state_retire_pending; 
+                    ch->mc_retire_scheduled = 0;
+                }
             }
         }
     }

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -1118,7 +1118,7 @@ void* picoquic_packet_loop_v3(void* v_ctx)
                     delta_t = time_check_arg.delta_t;
                 }
             }
-            // CHECK MC: Set delta lower on active multicast receivers, set to zero when MC_INTEGRITY frames have to be sent
+            // Set delta lower on active multicast receivers, set to zero when MC_INTEGRITY frames have to be sent
             picoquic_wake_for_multicast_frames(quic, mc_integrity_packet_threshold, current_time, &delta_t);
         }
         else {


### PR DESCRIPTION
* Finish implementation of `MC_RETIRE` frame
* Exit client application after channel retire
* Exit server application when all clients retired from the channel
* Fix socket loop wake handling to consider pending `MC_RETIRE` frames
* Add logic to retire channels and update multicast state when unicast connection is closed or an error occurs
* Leave multicast group and cleanup mcrx context when leaving or retiring a channel on client
* Cleanup all multicast context on `picoquic_free()`