### PR TITLE
Slightly enhance multicast rate limiting, fix memory allocation issues in sender thread

### DIFF
--- a/multicast_sample/multicast_sender.c
+++ b/multicast_sample/multicast_sender.c
@@ -244,28 +244,26 @@ static int multicast_sender_init(multicast_sender_ctx_t *sender_ctx,
 }
 
 /* Start multicast sender server */
-int multicast_sender_start(multicast_sender_ctx_t* sender_ctx) {
+int multicast_sender_start(multicast_sender_ctx_t* sender_ctx, int* thread_ret, picoquic_packet_loop_param_t* param) {
     int ret = 0;
-    int thread_ret = 0;
-    picoquic_packet_loop_param_t param = { 0 };
     multicast_server_ctx_t* server_ctx = sender_ctx->server_ctx;
 
     ret = multicast_sender_init(sender_ctx, server_ctx->mc_channel);
 
     /* Set the params for this thread */
-    param.multicast_channel = server_ctx->mc_channel;
-    param.local_port = server_ctx->sender_port;
-    param.force_localhost_src_ip = 1; /* Force localhost as src ip for multicast packets for local tests */
+    param->multicast_channel = server_ctx->mc_channel;
+    param->local_port = server_ctx->sender_port;
+    param->force_localhost_src_ip = 1; /* Force localhost as src ip for multicast packets for local tests */
 
     // CHECK MC: GSO deactivated currently due to issues with local interfaces, may be re-activated later?
-    param.do_not_use_gso = 1;
+    param->do_not_use_gso = 1;
 
     /* Start the background thread. */
-    sender_ctx->thread_ctx = picoquic_start_custom_network_thread_ex(server_ctx->quic, &param,
+    sender_ctx->thread_ctx = picoquic_start_custom_network_thread_ex(server_ctx->quic, param,
         picoquic_internal_thread_create, picoquic_internal_thread_delete,
         picoquic_internal_thread_setname, "multicast_sender", 
         picoquic_packet_loop_multicast_send,
-        NULL, NULL, &thread_ret);
+        NULL, NULL, thread_ret);
 
     ret = multicast_sender_mark_datagram_ready(sender_ctx);
 

--- a/multicast_sample/multicast_server.c
+++ b/multicast_sample/multicast_server.c
@@ -189,7 +189,7 @@ int multicast_server_callback(picoquic_cnx_t *cnx,
             // If data sending on multicast channel did not start yet, start now
             fprintf(stdout, "Callback picoquic_callback_multicast_join_attempted, joined clients: %i, threshold: %i\n", server_ctx->nb_joined_clients, server_ctx->client_threshold);
             if (!server_ctx->sender_running && server_ctx->nb_joined_clients >= server_ctx->client_threshold) {
-                int err = multicast_sender_start(&server_ctx->sender_app_ctx);
+                int err = multicast_sender_start(&server_ctx->sender_app_ctx, server_ctx->sender_thread_ret, server_ctx->sender_loop_params);
                 if (err == 0) {
                     server_ctx->sender_running = 1;
                     fprintf(stdout, "Multicast sender started\n");
@@ -278,6 +278,9 @@ int multicast_server(int server_port, int sender_port, const char *server_cert, 
     multicast_server_cnx_ctx_t default_context = {0}; // Per connection context
     multicast_server_ctx_t global_ctx = {0}; // Application global context
 
+    int sender_thread_ret = 0;
+    picoquic_packet_loop_param_t sender_loop_params = {0};
+
     global_ctx.served_filename = served_file;
     global_ctx.server_cert = server_cert;
     global_ctx.server_key = server_key;
@@ -285,6 +288,9 @@ int multicast_server(int server_port, int sender_port, const char *server_cert, 
     global_ctx.client_threshold = client_threshold;
     global_ctx.quic = quic;
     global_ctx.sender_app_ctx.server_ctx = &global_ctx;
+
+    global_ctx.sender_loop_params = &sender_loop_params;
+    global_ctx.sender_thread_ret = &sender_thread_ret;
 
     default_context.global_ctx = &global_ctx;
 

--- a/multicast_sample/picoquic_multicast.h
+++ b/multicast_sample/picoquic_multicast.h
@@ -76,6 +76,8 @@ typedef struct st_multicast_server_ctx_t
     int nb_joined_clients;
     int nb_active_clients;
     multicast_sender_ctx_t sender_app_ctx;
+    picoquic_packet_loop_param_t* sender_loop_params;
+    int* sender_thread_ret;
     int sender_running;
     int client_threshold;
     const char *server_cert; 
@@ -88,7 +90,7 @@ typedef struct st_multicast_server_ctx_t
 int multicast_client(char const *server_name, int server_port, 
     char const *default_dir, int max_rate);
 
-int multicast_sender_start(multicast_sender_ctx_t* sender_ctx);
+int multicast_sender_start(multicast_sender_ctx_t* sender_ctx, int* thread_ret, picoquic_packet_loop_param_t* param);
 
 int multicast_server(int server_port, int sender_port, const char *server_cert, 
     const char *server_key, int max_rate, const char *served_file, int client_threshold);

--- a/picoquic/multicast.c
+++ b/picoquic/multicast.c
@@ -75,7 +75,6 @@ int picoquic_mcrx_removed_socket_cb(
     channel->fd = 0;
     channel->socket_open = 0;
 
-    fprintf(stdout, "Debug: mcrx_removed_socket_cb called\n");
     return MCRX_ERR_OK;
 }
 

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -830,11 +830,13 @@ void* picoquic_packet_loop_multicast_send(void* v_ctx)
 
     // Very simple rate limiting according to announced limit of channel
     // ENHANCE MC: Enhance rate limiting 
-    struct timespec start_time, current_time;
-    timespec_get(&start_time, TIME_UTC);
+    struct timespec start_time_sec, start_time_millisec, current_time;
+    timespec_get(&start_time_sec, TIME_UTC);
+    memcpy(&start_time_millisec, &start_time_sec, sizeof(struct timespec));
 
     size_t bytes_sent_per_second = 0;
-    int max_bytes_per_second = ((int)mc_channel->max_rate * 128); // max rate is in kibps, 1 kib = 128 byte
+    size_t bytes_sent_per_millisec = 0;
+    size_t max_bytes_per_millisec = ((int)mc_channel->max_rate * 128) / 1000; // max rate is in kibit per sec, 1 kibit = 128 byte
 
     /* Start of Packet Loop */
     while (ret == 0 && !thread_ctx->thread_should_close) {
@@ -848,127 +850,133 @@ void* picoquic_packet_loop_multicast_send(void* v_ctx)
             int sock_ret = 0;
             int sock_err = 0;
 
-            int remaining_capacity = max_bytes_per_second - bytes_sent_per_second;
-            if (remaining_capacity > 0) {
+            int remaining_capacity = (int)(max_bytes_per_millisec - bytes_sent_per_millisec);
+            if (remaining_capacity > 100) {
+                // TODO MC: Make sure that packets are only prepared with max. remaining_capacity bytes
+                // Currently, as long as at least 100 byte is still remaining, the method prepares
+                // a packet of arbitrary length
                 ret = picoquic_prepare_next_packet_multicast(quic,
                     send_buffer, send_buffer_size, &send_length,
                     &peer_addr, &local_addr, mc_channel,
                     send_msg_ptr);
-            } else {
-                send_length = 0;
-            }
-
-            if (ret != 0 || send_length <= 0) { 
-                break;
-            }
-
-            /* If send_msg_size is defined, sendmsg may send more than one packet.
-                * We compute that to update the number of packets sent in the loop.
-                */
-            nb_packets_sent += (send_msg_size == 0) ? 1 :
-                (send_length + send_msg_size - 1) / (send_msg_size);
-            if (send_length > param->send_length_max) {
-                param->send_length_max = send_length;
-            }
             
-            SOCKET_TYPE send_socket = s_ctx[0].fd;
-            bytes_sent += send_length;
-            bytes_sent_per_second += send_length;
+                if (ret == 0 && send_length > 0) {
+                    /* If send_msg_size is defined, sendmsg may send more than one packet.
+                        * We compute that to update the number of packets sent in the loop.
+                        */
+                    nb_packets_sent += (send_msg_size == 0) ? 1 :
+                        (send_length + send_msg_size - 1) / (send_msg_size);
+                    if (send_length > param->send_length_max) {
+                        param->send_length_max = send_length;
+                    }
+                    
+                    SOCKET_TYPE send_socket = s_ctx[0].fd;
+                    bytes_sent += send_length;
+                    bytes_sent_per_second += send_length;
+                    bytes_sent_per_millisec += send_length;
 
-            // Force 127.0.0.1 as src ip for local tests
-            if (param->force_localhost_src_ip) {
-                picoquic_store_text_addr(&local_addr, "127.0.0.1", 0);
-            }
+                    // Force 127.0.0.1 as src ip for local tests
+                    if (param->force_localhost_src_ip) {
+                        picoquic_store_text_addr(&local_addr, "127.0.0.1", 0);
+                    }
 
-            // WORKAROUND: For whatever reason, in picoquic the port in every sockaddr struct is usually stored in host byte order.
-            // To get multicast working, we have to convert the port of the group address to network byte order before calling picoquic_sendmsg()
-            if (peer_addr.ss_family == AF_INET) {
-                ((struct sockaddr_in*)&peer_addr)->sin_port = htons(((struct sockaddr_in*)&peer_addr)->sin_port);
-            } else if (peer_addr.ss_family == AF_INET6) {
-                ((struct sockaddr_in6*)&peer_addr)->sin6_port = htons(((struct sockaddr_in6*)&peer_addr)->sin6_port);
-            }
+                    // WORKAROUND: For whatever reason, in picoquic the port in every sockaddr struct is usually stored in host byte order.
+                    // To get multicast working, we have to convert the port of the group address to network byte order before calling picoquic_sendmsg()
+                    if (peer_addr.ss_family == AF_INET) {
+                        ((struct sockaddr_in*)&peer_addr)->sin_port = htons(((struct sockaddr_in*)&peer_addr)->sin_port);
+                    } else if (peer_addr.ss_family == AF_INET6) {
+                        ((struct sockaddr_in6*)&peer_addr)->sin6_port = htons(((struct sockaddr_in6*)&peer_addr)->sin6_port);
+                    }
 
-            if (send_socket == INVALID_SOCKET) {
-                sock_ret = -1;
-                sock_err = -1;
-            }
-            else
-            {
-                if (param->simulate_eio && send_length > PICOQUIC_MAX_PACKET_SIZE) {
-                    /* Test hook, simulating a driver that does not support GSO */
-                    sock_ret = -1;
-                    sock_err = EIO;
-                    param->simulate_eio = 0;
-                }
-                else {
-                    sock_ret = picoquic_sendmsg(send_socket,
-                        (struct sockaddr*)&peer_addr, (struct sockaddr*)&local_addr, 0,
-                        (const char*)send_buffer, (int)send_length, (int)send_msg_size, &sock_err);
-                }
-            }
-            if (sock_ret <= 0) {
-                /* TODO: add a test in which the socket fails. */
-                // CLEAN MC: Refactor logging without using stdout
-                fprintf(stdout, "Could not send message to AF_to=%d, AF_from=%d, ret=%d, err=%d\n",
-                    peer_addr.ss_family, local_addr.ss_family, sock_ret, sock_err);
-
-                if (sock_err == EIO) {
-                    /* TODO: this is an error encountered if the system supports GSO, but
-                        * the specific interface driver does not. Main example is Mininet.
-                        * Not sure that we can treat that correctly. Try to minimize the
-                        * amount of untested code? Rely on config flag? Rely on error
-                        * recovery? */
-                    size_t packet_index = 0;
-                    size_t packet_size = send_msg_size;
-
-                    while (packet_index < send_length) {
-                        if (packet_index + packet_size > send_length) {
-                            packet_size = send_length - packet_index;
-                        }
-                        sock_ret = picoquic_sendmsg(send_socket,
-                            (struct sockaddr*)&peer_addr, (struct sockaddr*)&local_addr, 0,
-                            (const char*)(send_buffer + packet_index), (int)packet_size, 0, &sock_err);
-                        if (sock_ret > 0) {
-                            packet_index += packet_size;
+                    if (send_socket == INVALID_SOCKET) {
+                        sock_ret = -1;
+                        sock_err = -1;
+                    }
+                    else
+                    {
+                        if (param->simulate_eio && send_length > PICOQUIC_MAX_PACKET_SIZE) {
+                            /* Test hook, simulating a driver that does not support GSO */
+                            sock_ret = -1;
+                            sock_err = EIO;
+                            param->simulate_eio = 0;
                         }
                         else {
-                            fprintf(stdout, "Retry with packet size=%zu fails at index %zu, ret=%d, err=%d.\n",
-                                packet_size, packet_index, sock_ret, sock_err);
-                            break;
+                            sock_ret = picoquic_sendmsg(send_socket,
+                                (struct sockaddr*)&peer_addr, (struct sockaddr*)&local_addr, 0,
+                                (const char*)send_buffer, (int)send_length, (int)send_msg_size, &sock_err);
                         }
                     }
-                    if (sock_ret > 0) {
-                        fprintf(stdout, "Retry of %zu bytes by chunks of %zu bytes succeeds.\n",
-                            send_length, send_msg_size);
-                    }
-                    if (send_msg_ptr != NULL) {
-                        /* Make sure that we do not use GSO anymore in this run */
-                        send_msg_ptr = NULL;
-                        fprintf(stdout, "%s", "UDP GSO was disabled\n");
+                    if (sock_ret <= 0) {
+                        /* TODO: add a test in which the socket fails. */
+                        // CLEAN MC: Refactor logging without using stdout
+                        fprintf(stdout, "Could not send message to AF_to=%d, AF_from=%d, ret=%d, err=%d\n",
+                            peer_addr.ss_family, local_addr.ss_family, sock_ret, sock_err);
+
+                        if (sock_err == EIO) {
+                            /* TODO: this is an error encountered if the system supports GSO, but
+                                * the specific interface driver does not. Main example is Mininet.
+                                * Not sure that we can treat that correctly. Try to minimize the
+                                * amount of untested code? Rely on config flag? Rely on error
+                                * recovery? */
+                            size_t packet_index = 0;
+                            size_t packet_size = send_msg_size;
+
+                            while (packet_index < send_length) {
+                                if (packet_index + packet_size > send_length) {
+                                    packet_size = send_length - packet_index;
+                                }
+                                sock_ret = picoquic_sendmsg(send_socket,
+                                    (struct sockaddr*)&peer_addr, (struct sockaddr*)&local_addr, 0,
+                                    (const char*)(send_buffer + packet_index), (int)packet_size, 0, &sock_err);
+                                if (sock_ret > 0) {
+                                    packet_index += packet_size;
+                                }
+                                else {
+                                    fprintf(stdout, "Retry with packet size=%zu fails at index %zu, ret=%d, err=%d.\n",
+                                        packet_size, packet_index, sock_ret, sock_err);
+                                    break;
+                                }
+                            }
+                            if (sock_ret > 0) {
+                                fprintf(stdout, "Retry of %zu bytes by chunks of %zu bytes succeeds.\n",
+                                    send_length, send_msg_size);
+                            }
+                            if (send_msg_ptr != NULL) {
+                                /* Make sure that we do not use GSO anymore in this run */
+                                send_msg_ptr = NULL;
+                                fprintf(stdout, "%s", "UDP GSO was disabled\n");
+                            }
+                        }
                     }
                 }
+            }
+
+            // Rate limiting
+            timespec_get(&current_time, TIME_UTC);
+            double elapsed_seconds = (current_time.tv_sec - start_time_sec.tv_sec) +
+                                    ((current_time.tv_nsec - start_time_sec.tv_nsec) / 1e9);
+
+            double elapsed_milliseconds = ((current_time.tv_sec - start_time_millisec.tv_sec) +
+                                    (current_time.tv_nsec - start_time_millisec.tv_nsec) / 1e9) * 1000;
+
+            if (elapsed_milliseconds >= 1.0) {
+                bytes_sent_per_millisec = 0; 
+                timespec_get(&start_time_millisec, TIME_UTC);
+            }
+
+            if (elapsed_seconds >= 1.0) {
+                printf("Total sent: %ld bytes = %lf kibit in 1 second, max = %d kibit per second\n", bytes_sent_per_second, ((double)bytes_sent_per_second / 128), (int)mc_channel->max_rate);
+                bytes_sent_per_second = 0; 
+                timespec_get(&start_time_sec, TIME_UTC);
             }
         }
 
+        // After each 10 packets, run callback
         if (ret == 0) {
             if (loop_callback != NULL) {
                 ret = loop_callback(quic, picoquic_packet_loop_after_send, loop_callback_ctx, &bytes_sent);
             }
         }
-
-        // Rate limiting
-        timespec_get(&current_time, TIME_UTC);
-        double elapsed_seconds = (current_time.tv_sec - start_time.tv_sec) +
-                                (current_time.tv_nsec - start_time.tv_nsec) / 1e9;
-
-        if (elapsed_seconds >= 1.0) {
-            printf("Total sent: %ld bytes = %lf mib in 1 second\n", bytes_sent_per_second, ((double)bytes_sent_per_second / 131072));
-            bytes_sent_per_second = 0; 
-            timespec_get(&start_time, TIME_UTC);
-        }
-
-        struct timespec ts = {0, (long)(10000000)};
-        nanosleep(&ts, NULL);
     }
 
     thread_ctx->thread_is_ready = 0;


### PR DESCRIPTION
Enhance rate limiting:

* The loop can now use a maximum data capacity per millisecond, according to the fixed `max_rate´
* Remove random sleep after each loop

 Other:

* Fix memory scope issues in sender thread, handle all memory in server thread